### PR TITLE
Docs: baseline docs & diagrams (no code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,702 @@
-# goagent
+# goagent — Minimal, safe, non‑interactive agent CLI
+
+[![CI (lint+test+build)](https://github.com/hyperifyio/goagent/actions/workflows/ci.yml/badge.svg)](https://github.com/hyperifyio/goagent/actions/workflows/ci.yml)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/hyperifyio/goagent)](https://github.com/hyperifyio/goagent/blob/main/go.mod)
+[![Go Reference](https://pkg.go.dev/badge/github.com/hyperifyio/goagent.svg)](https://pkg.go.dev/github.com/hyperifyio/goagent)
+[![Release](https://img.shields.io/github/v/release/hyperifyio/goagent?sort=semver)](https://github.com/hyperifyio/goagent/releases)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+goagent is a compact, vendor‑agnostic command‑line tool for running non‑interactive, tool‑using agents against any OpenAI‑compatible Chat Completions API. It executes a small, auditable allowlist of local tools (argv only; no shell), streams JSON in/out, and prints a concise final answer.
+
+- Why use it: deterministic, portable, and safe by default. Works with hosted providers and with local endpoints like `http://localhost:1234/v1`.
+- Who it’s for: engineers who want a minimal agent runner with clear guarantees and zero vendor lock‑in.
+- What makes it different: strict "argv‑only" tool execution, explicit allowlists, and a pragmatic default LLM policy for predictable behavior across providers.
+
+## Table of contents
+- [At a glance](#at-a-glance)
+- [Features](#features)
+- [Installation](#installation)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+  - [Common flags](#common-flags)
+  - [Image generation flags](#image-generation-flags)
+  - [Why you usually don’t need to change knobs](#why-you-usually-dont-need-to-change-knobs)
+  - [Capabilities](#capabilities)
+- [Configuration](#configuration)
+  - [Inheritance and precedence](#inheritance-and-precedence)
+- [Examples](#examples)
+  - [Zero-config with GPT-5](#zero-config-with-gpt-5)
+  - [Tool calls transcript](#tool-calls-transcript)
+  - [Worked example: tool calls and transcript](#worked-example-tool-calls-and-transcript)
+  - [View refined messages (pre-stage and final)](#view-refined-messages-pre-stage-and-final)
+  - [Exec tool](#exec-tool)
+  - [Filesystem tools](#filesystem-tools)
+  - [Image generation tool (img_create)](#image-generation-tool-img_create)
+  - [fs_search](#fs_search)
+- [Security](#security)
+- [Troubleshooting](#troubleshooting)
+- [Tests](#tests)
+ - [Documentation](#documentation)
+- [Diagrams](#diagrams)
+- [Contributing](#contributing)
+- [Development tooling](#tooling)
+- [Support](#support)
+- [Roadmap](#roadmap)
+- [Project status](#project-status)
+- [License and credits](#license-and-credits)
+- [Changelog](#changelog)
+- [More examples](#more-examples)
+- [CI quality gates](docs/operations/ci-quality-gates.md)
+ - [State persistence (-state-dir)](#state-persistence--state-dir)
+
+
+## At a glance
+- Minimal, portable, vendor‑agnostic: works with any OpenAI‑compatible endpoint
+- Deterministic and auditable: argv‑only tool execution, JSON stdin/stdout, strict timeouts
+- Safe by default: explicit allowlist of tools; no shell evaluation
+- Batteries included: a small toolbelt for filesystem, process, network, and image tasks
+
+## Features
+- OpenAI‑compatible `POST /v1/chat/completions` via `net/http` (no SDK)
+- **Explicit tools allowlist**: `tools.json` with JSON Schema parameters (see [Tools manifest reference](docs/reference/tools-manifest.md))
+- **Deterministic execution**: argv‑only tools, JSON stdin/stdout, per‑call timeouts
+- **Predictable error surface**: tool errors mapped as structured JSON
+- **Observability & hygiene**: audit logging with redaction; transcript size controls
+
+## Installation
+
+### Requirements
+- Go 1.24+ on Linux, macOS, or Windows
+- Network access to an OpenAI‑compatible API
+- For development and examples: `ripgrep` (rg), `jq`, and `golangci-lint`
+
+### Install options
+1) Download a binary: see [Releases](https://github.com/hyperifyio/goagent/releases)
+
+2) With Go (adds `agentcli` to your `GOBIN`):
+```bash
+go install github.com/hyperifyio/goagent/cmd/agentcli@latest
+```
+
+3) Build from source:
+```bash
+git clone https://github.com/hyperifyio/goagent
+cd goagent
+make bootstrap tidy build build-tools
+```
+
+Verify installation:
+```bash
+./bin/agentcli --version
+```
+
+Developer prerequisites (examples):
+```bash
+# ripgrep
+# - Ubuntu/Debian
+sudo apt-get update && sudo apt-get install -y ripgrep
+# - macOS (Homebrew)
+brew install ripgrep
+# - Windows (Chocolatey)
+choco install ripgrep -y
+
+# golangci-lint (pinned; installs into ./bin via Makefile)
+make install-golangci
+./bin/golangci-lint version
+
+# jq (used by examples and runbooks)
+# - Ubuntu/Debian
+sudo apt-get install -y jq
+# - macOS (Homebrew)
+brew install jq
+# - Windows (Chocolatey)
+choco install jq -y
+
+# make (Windows, for running Makefile targets used in docs)
+# - Windows (Chocolatey)
+choco install make -y
+```
+
+## Configuration
+Configuration precedence is: **flags > environment > built‑in defaults**.
+
+Environment variables:
+- `OAI_BASE_URL` — API base (default `https://api.openai.com/v1`). Helper scripts will also read `LLM_BASE_URL` if present.
+- `OAI_MODEL` — model ID (default `oss-gpt-20b`). Helper scripts will also read `LLM_MODEL` if present.
+- `OAI_API_KEY` — API key when required. The CLI also accepts `OPENAI_API_KEY` for compatibility.
+- `OAI_HTTP_TIMEOUT` — HTTP timeout for chat requests (e.g., `90s`). Mirrors `-http-timeout`.
+  `OAI_PREP_HTTP_TIMEOUT` — HTTP timeout for pre-stage; overrides inheritance from `-http-timeout`.
+
+### Inheritance and precedence
+
+The CLI resolves values independently for chat (main), pre-stage, and image flows, with inheritance when explicit values are not provided.
+
+Endpoints and API keys:
+
+| Setting | Resolution order |
+|---|---|
+| Chat base URL | `-base-url` → `OAI_BASE_URL` → default `https://api.openai.com/v1` |
+| Pre-stage base URL | `-prep-base-url` → `OAI_PREP_BASE_URL` → inherit Chat base URL |
+| Image base URL | `-image-base-url` → `OAI_IMAGE_BASE_URL` → inherit Chat base URL |
+| Chat API key | `-api-key` → `OAI_API_KEY` → `OPENAI_API_KEY` |
+| Pre-stage API key | `-prep-api-key` → `OAI_PREP_API_KEY` → inherit Chat API key |
+| Image API key | `-image-api-key` → `OAI_IMAGE_API_KEY` → inherit Chat API key |
+
+Models and sampling:
+
+| Setting | Resolution order |
+|---|---|
+| Chat model | `-model` → `OAI_MODEL` → default `oss-gpt-20b` |
+| Pre-stage model | `-prep-model` → `OAI_PREP_MODEL` → inherit Chat model |
+| Image model | `-image-model` → `OAI_IMAGE_MODEL` → default `gpt-image-1` |
+| Chat temperature vs top-p | One‑knob rule: if `-top-p` is set, omit `temperature`; otherwise send `-temp` (default 1.0) when supported |
+| Pre-stage temperature vs top-p | One‑knob rule applies independently with `-prep-temp`/`-prep-top-p` |
+
+HTTP controls:
+
+| Setting | Resolution order |
+|---|---|
+| Chat HTTP timeout | `-http-timeout` → `OAI_HTTP_TIMEOUT` → fallback to `-timeout` if set |
+| Pre-stage HTTP timeout | `-prep-http-timeout` → `OAI_PREP_HTTP_TIMEOUT` → inherit Chat HTTP timeout |
+| Image HTTP timeout | `-image-http-timeout` → `OAI_IMAGE_HTTP_TIMEOUT` → inherit Chat HTTP timeout |
+| Chat HTTP retries | `-http-retries` → `OAI_HTTP_RETRIES` → default (e.g., 2) |
+| Pre-stage HTTP retries | `-prep-http-retries` → `OAI_PREP_HTTP_RETRIES` → inherit Chat HTTP retries |
+| Image HTTP retries | `-image-http-retries` → `OAI_IMAGE_HTTP_RETRIES` → inherit Chat HTTP retries |
+| Chat HTTP retry backoff | `-http-retry-backoff` → `OAI_HTTP_RETRY_BACKOFF` → default |
+| Pre-stage HTTP retry backoff | `-prep-http-retry-backoff` → `OAI_PREP_HTTP_RETRY_BACKOFF` → inherit Chat backoff |
+| Image HTTP retry backoff | `-image-http-retry-backoff` → `OAI_IMAGE_HTTP_RETRY_BACKOFF` → inherit Chat backoff |
+
+## Quick start
+Install the CLI and point it to a reachable OpenAI‑compatible API (local or hosted):
+```bash
+export OAI_BASE_URL=http://localhost:1234/v1
+export OAI_MODEL=oss-gpt-20b
+make build build-tools # skip if installed via go install / release binary
+```
+
+Create a minimal `tools.json` next to the binary (Unix/macOS):
+```json
+{
+  "tools": [
+    {
+      "name": "get_time",
+      "description": "Return current time for an IANA timezone (default UTC). Accepts 'timezone' (canonical) and alias 'tz'.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "timezone": {"type": "string", "description": "e.g. Europe/Helsinki"},
+          "tz": {"type": "string", "description": "Alias for timezone (deprecated)"}
+        },
+        "required": ["timezone"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/get_time"],
+      "timeoutSec": 5
+    }
+  ]
+}
+```
+
+On Windows, use a `.exe` suffix for tool binaries:
+```json
+{
+  "tools": [
+    {
+      "name": "get_time",
+      "schema": {"type":"object","properties":{"timezone":{"type":"string"}},"required":["timezone"],"additionalProperties":false},
+      "command": ["./tools/bin/get_time.exe"],
+      "timeoutSec": 5
+    }
+  ]
+}
+```
+
+Run the agent:
+```bash
+./bin/agentcli \
+  -prompt "What's the local time in Helsinki? If tools are available, call get_time." \
+  -tools ./tools.json \
+  -debug
+```
+
+Expected behavior: the model may call `get_time`; the CLI executes `./tools/bin/get_time` (or `get_time.exe` on Windows) with JSON on stdin, appends the result as a `tool` message, calls the API again, then prints a concise final answer.
+
+Tip: run `./bin/agentcli -h` for the complete help output.
+
+## Usage
+Flags are order‑insensitive. You can place `-prompt` and other flags in any order; precedence remains flag > environment > default.
+### Common flags
+```text
+-prompt string         User prompt (required)
+-tools string          Path to tools.json (optional)
+-system string         System prompt (default: helpful and precise)
+-base-url string       OpenAI‑compatible base URL (env OAI_BASE_URL; scripts accept LLM_BASE_URL fallback)
+-api-key string        API key if required (env OAI_API_KEY; falls back to OPENAI_API_KEY)
+-model string          Model ID (env OAI_MODEL; scripts accept LLM_MODEL fallback)
+-max-steps int         Maximum reasoning/tool steps (default 8)
+                       A hard ceiling of 15 is enforced; exceeding the cap
+                       terminates with: "needs human review".
+-http-timeout duration HTTP timeout for chat completions (env OAI_HTTP_TIMEOUT; default falls back to -timeout)
+-prep-http-timeout duration HTTP timeout for pre-stage (env OAI_PREP_HTTP_TIMEOUT; default falls back to -http-timeout)
+-prep-model string      Pre-stage model ID (env OAI_PREP_MODEL; inherits -model if unset)
+-prep-base-url string   Pre-stage base URL (env OAI_PREP_BASE_URL; inherits -base-url if unset)
+-prep-api-key string    Pre-stage API key (env OAI_PREP_API_KEY; falls back to OAI_API_KEY/OPENAI_API_KEY; inherits -api-key if unset)
+-prep-http-retries int  Pre-stage HTTP retries (env OAI_PREP_HTTP_RETRIES; inherits -http-retries if unset)
+-prep-http-retry-backoff duration Pre-stage HTTP retry backoff (env OAI_PREP_HTTP_RETRY_BACKOFF; inherits -http-retry-backoff if unset)
+-prep-dry-run           Run pre-stage only, print refined Harmony messages to stdout, and exit 0
+-print-messages         Pretty-print the final merged message array to stderr before the main call
+-http-retries int      Number of retries for transient HTTP failures (timeouts, 429, 5xx). Uses jittered exponential backoff. (default 2)
+-http-retry-backoff duration Base backoff between HTTP retry attempts (exponential with jitter). (default 300ms)
+-tool-timeout duration Per-tool timeout (default falls back to -timeout)
+-timeout duration      [DEPRECATED] Global timeout; prefer -http-timeout and -tool-timeout
+-temp float            Sampling temperature (default 1.0)
+-top-p float           Nucleus sampling probability mass (conflicts with -temp; omits temperature when set)
+-prep-top-p float      Nucleus sampling probability mass for pre-stage (conflicts with -temp; omits temperature when set)
+-prep-profile string   Pre-stage prompt profile (deterministic|general|creative|reasoning); sets temperature when supported (conflicts with -prep-top-p)
+-prep-enabled          Enable pre-stage (default true). When false, skip pre-stage and proceed directly to main call.
+-debug                 Dump request/response JSON to stderr
+-verbose               Also print non-final assistant channels (critic/confidence) to stderr
+-channel-route name=stdout|stderr|omit
+                       Override default channel routing (final→stdout, critic/confidence→stderr); repeatable
+-quiet                 Suppress non-final output; print only final text to stdout
+-capabilities          Print enabled tools and exit
+-print-config          Print resolved config and exit
+-dry-run               Print intended state actions (restore/refine/save) and exit without writing state
+--version | -version   Print version and exit
+```
+Run `./bin/agentcli -h` to see the built‑in help.
+
+### Image generation flags
+
+The following flags control the Images API behavior used by the assistant when generating images. Precedence is always: flags > environment > inheritance > default.
+
+| Flag | Environment | Default / Inheritance | Description |
+|---|---|---|---|
+| `-image-base-url string` | `OAI_IMAGE_BASE_URL` | Inherits `-base-url` | Image API base URL |
+| `-image-api-key string` | `OAI_IMAGE_API_KEY` | Inherits `-api-key`; falls back to `OPENAI_API_KEY` | API key for Images API |
+| `-image-model string` | `OAI_IMAGE_MODEL` | `gpt-image-1` | Images model ID |
+| `-image-http-timeout duration` | `OAI_IMAGE_HTTP_TIMEOUT` | Inherits `-http-timeout` | HTTP timeout for image requests |
+| `-image-http-retries int` | `OAI_IMAGE_HTTP_RETRIES` | Inherits `-http-retries` | Retry attempts for transient image HTTP errors |
+| `-image-http-retry-backoff duration` | `OAI_IMAGE_HTTP_RETRY_BACKOFF` | Inherits `-http-retry-backoff` | Base backoff for image HTTP retries |
+| `-image-n int` | `OAI_IMAGE_N` | `1` | Number of images to generate |
+| `-image-size string` | `OAI_IMAGE_SIZE` | `1024x1024` | Size WxH |
+| `-image-quality string` | `OAI_IMAGE_QUALITY` | `standard` | `standard` or `hd` |
+| `-image-style string` | `OAI_IMAGE_STYLE` | `natural` | `natural` or `vivid` |
+| `-image-response-format string` | `OAI_IMAGE_RESPONSE_FORMAT` | `url` | `url` or `b64_json` |
+| `-image-transparent-background` | `OAI_IMAGE_TRANSPARENT_BACKGROUND` | `false` | Request transparent background when supported |
+
+### Why you usually don’t need to change knobs
+- The default `-temp 1.0` is standardized for broad provider/model parity and GPT‑5 compatibility.
+- The one‑knob rule applies: if you set `-top-p`, the agent omits `temperature`; otherwise it sends `temperature` (default 1.0) and leaves `top_p` unset.
+- The one‑knob rule applies for both stages: if you set `-top-p` (or `-prep-top-p`), the agent omits `temperature` for that stage; otherwise it sends `temperature` (default 1.0) when supported. Pre‑stage profiles are available via `-prep-profile`, e.g. `deterministic` sets temperature to 0.1 when supported.
+- See the policy for details and rationale: [ADR‑0004: Default LLM policy](docs/adr/0004-default-llm-policy.md).
+
+### Capabilities
+List enabled tools from a manifest without running the agent. The output includes a prominent header warning, and certain tools like `img_create` are annotated with an extra warning because they make outbound network calls and can save files:
+```bash
+./bin/agentcli -tools ./tools.json -capabilities
+```
+
+## Examples
+### Zero-config with GPT-5
+Run against a GPT‑5 compatible endpoint without tuning sampling knobs. The CLI sends `temperature: 1.0` by default for models that support it.
+```bash
+./bin/agentcli -prompt "Say ok" -model gpt-5 -base-url "$OAI_BASE_URL" -api-key "$OAI_API_KEY" -max-steps 1 -debug
+# stderr will include a request dump containing "\"temperature\": 1"
+```
+
+### Tool calls transcript
+Minimal JSON transcript showing correct tool‑call sequencing:
+```json
+[
+  {"role":"user","content":"What's the local time in Helsinki?"},
+  {
+    "role":"assistant",
+    "content":null,
+    "tool_calls":[
+      {
+        "id":"call_get_time_1",
+        "type":"function",
+        "function":{
+          "name":"get_time",
+          "arguments":"{\"timezone\":\"Europe/Helsinki\"}"
+        }
+      }
+    ]
+  },
+  {
+    "role":"tool",
+    "tool_call_id":"call_get_time_1",
+    "name":"get_time",
+    "content":"{\"timezone\":\"Europe/Helsinki\",\"iso\":\"2025-08-17T12:34:56Z\",\"unix\":1755424496}"
+  },
+  {"role":"assistant","content":"It's 15:34 in Helsinki."}
+]
+```
+Notes:
+- For parallel tool calls (multiple entries in `tool_calls`), append one `role:"tool"` message per `id` before calling the API again. Order of tool messages is not significant as long as each `tool_call_id` is present exactly once.
+- Transcript hygiene: when running without `-debug`, the CLI replaces any single tool message content larger than 8 KiB with `{"truncated":true,"reason":"large-tool-output"}` before sending to the API. Use `-debug` to inspect full payloads during troubleshooting.
+
+### Worked example: tool calls and transcript
+See `examples/tool_calls.md` for a self-contained, test-driven worked example that:
+- Exercises default temperature 1.0
+- Demonstrates a two-tool-call interaction with matching `tool_call_id`
+- Captures a transcript via `-debug` showing request/response JSON dumps
+
+Run the example test:
+```bash
+go test ./examples -run TestWorkedExample_ToolCalls_TemperatureOne_Sequencing -v
+```
+
+### Split backends for chat and image
+
+Use one provider for chat and another for image generation by overriding the image backend only:
+
+```bash
+export OAI_BASE_URL=https://api.example-chat.local/v1
+export OAI_API_KEY=chat-key
+
+./bin/agentcli \
+  -prompt "Create a simple logo" \
+  -tools ./tools.json \
+  -image-base-url https://api.openai.com/v1 \
+  -image-api-key "$OPENAI_API_KEY" \
+  -image-model gpt-image-1 \
+  -image-size 1024x1024
+```
+
+### View refined messages (pre-stage and final)
+See also ADR‑0005 for the pre‑stage flow and channel routing details: `docs/adr/0005-harmony-pre-processing-and-channel-aware-output.md`.
+Inspect message arrays deterministically without running the full loop:
+
+```bash
+# Pre-stage only: print refined Harmony messages and exit
+./bin/agentcli -prompt "Say ok" -prep-dry-run | jq .
+
+# Before the main call: pretty-print merged messages to stderr, then proceed
+./bin/agentcli -prompt "Say ok" -print-messages 2> >(jq .)
+```
+
+### Exec tool
+Build the exec tool and run a simple command (Unix):
+```bash
+make build-tools
+echo '{"cmd":"/bin/echo","args":["hello"]}' | ./tools/bin/exec
+# => {"exitCode":0,"stdout":"hello\n","stderr":"","durationMs":<n>}
+```
+Timeout example:
+```bash
+echo '{"cmd":"/bin/sleep","args":["2"],"timeoutSec":1}' | ./tools/bin/exec
+# => non-zero exit, stderr contains "timeout"
+```
+
+### Filesystem tools
+The following examples assume `make build-tools` has produced binaries into `tools/bin/*`.
+
+#### fs_read_file
+```bash
+make build-tools
+printf 'hello world' > tmp_readme_demo.txt
+echo '{"path":"tmp_readme_demo.txt"}' | ./tools/bin/fs_read_file | jq .
+rm -f tmp_readme_demo.txt
+```
+
+#### fs_append_file
+```bash
+make build-tools
+echo -n 'hello ' | base64 > b64a.txt
+echo -n 'world'  | base64 > b64b.txt
+echo '{"path":"tmp_append_demo.txt","contentBase64":"'"$(cat b64a.txt)"'"}' | ./tools/bin/fs_append_file | jq .
+echo '{"path":"tmp_append_demo.txt","contentBase64":"'"$(cat b64b.txt)"'"}' | ./tools/bin/fs_append_file | jq .
+cat tmp_append_demo.txt; rm -f tmp_append_demo.txt b64a.txt b64b.txt
+```
+
+#### fs_write_file
+```bash
+make build-tools
+echo -n 'hello world' | base64 > b64.txt
+echo '{"path":"tmp_write_demo.txt","contentBase64":"'"$(cat b64.txt)"'"}' | ./tools/bin/fs_write_file | jq .
+cat tmp_write_demo.txt; rm -f tmp_write_demo.txt b64.txt
+```
+
+#### fs_mkdirp
+```bash
+make build-tools
+echo '{"path":"tmp_mkdirp_demo/a/b/c","modeOctal":"0755"}' | ./tools/bin/fs_mkdirp | jq .
+ls -ld tmp_mkdirp_demo/a/b/c
+echo '{"path":"tmp_mkdirp_demo/a/b/c","modeOctal":"0755"}' | ./tools/bin/fs_mkdirp | jq .
+rm -rf tmp_mkdirp_demo
+```
+
+#### fs_rm
+```bash
+make build-tools
+printf 'temp' > tmp_rm_demo.txt
+echo '{"path":"tmp_rm_demo.txt"}' | ./tools/bin/fs_rm | jq .
+mkdir -p tmp_rm_dir/a/b && touch tmp_rm_dir/a/b/file.txt
+echo '{"path":"tmp_rm_dir","recursive":true}' | ./tools/bin/fs_rm | jq .
+rm -rf tmp_rm_dir
+```
+
+#### fs_move
+```bash
+make build-tools
+printf 'payload' > tmp_move_src.txt
+echo '{"from":"tmp_move_src.txt","to":"tmp_move_dst.txt"}' | ./tools/bin/fs_move | jq .
+printf 'old' > tmp_move_dst.txt; printf 'new' > tmp_move_src.txt
+echo '{"from":"tmp_move_src.txt","to":"tmp_move_dst.txt","overwrite":true}' | ./tools/bin/fs_move | jq .
+rm -f tmp_move_src.txt tmp_move_dst.txt
+```
+
+#### fs_listdir
+```bash
+make build-tools
+mkdir -p tmp_listdir_demo/a b && touch tmp_listdir_demo/.hidden tmp_listdir_demo/a/afile tmp_listdir_demo/bfile
+echo '{"path":"tmp_listdir_demo"}' | ./tools/bin/fs_listdir | jq '.entries | map(.path)'
+jq -n '{path:"tmp_listdir_demo",recursive:true,globs:["**/*"],includeHidden:false}' | ./tools/bin/fs_listdir | jq '.entries | map(select(.type=="file") | .path)'
+rm -rf tmp_listdir_demo
+```
+
+#### fs_apply_patch
+```bash
+make build-tools
+cat > /tmp/demo.diff <<'EOF'
+--- /dev/null
++++ b/tmp_patch_demo.txt
+@@ -0,0 +1,2 @@
++hello
++world
+EOF
+jq -n --arg d "$(cat /tmp/demo.diff)" '{unifiedDiff:$d}' | ./tools/bin/fs_apply_patch | jq .
+printf 'hello
+world
+' | diff -u - tmp_patch_demo.txt && echo OK
+```
+
+#### fs_edit_range
+```bash
+make build-tools
+printf 'abcdef' > tmp_edit_demo.txt
+echo -n 'XY' | base64 > b64.txt
+jq -n --arg b "$(cat b64.txt)" '{path:"tmp_edit_demo.txt",startByte:2,endByte:4,replacementBase64:$b}' | ./tools/bin/fs_edit_range | jq .
+cat tmp_edit_demo.txt # => abXYef
+rm -f tmp_edit_demo.txt b64.txt
+```
+
+#### fs_stat
+```bash
+make build-tools
+printf 'hello world' > tmp_stat_demo.txt
+echo '{"path":"tmp_stat_demo.txt","hash":"sha256"}' | ./tools/bin/fs_stat | jq .
+rm -f tmp_stat_demo.txt
+```
+
+### Image generation tool (img_create)
+
+Generate images via an OpenAI‑compatible Images API and save files into your repository (default) or return base64 on demand.
+
+Quickstart (Unix/macOS/Windows via `make build-tools`):
+
+```bash
+make build-tools
+```
+
+Minimal `tools.json` entry (copy/paste next to your binary):
+
+```json
+{
+  "tools": [
+    {
+      "name": "img_create",
+      "description": "Generate image(s) with OpenAI Images API and save to repo or return base64",
+      "schema": {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+          "prompt": {"type": "string"},
+          "n": {"type": "integer", "minimum": 1, "maximum": 4, "default": 1},
+          "size": {"type": "string", "pattern": "^\\d{3,4}x\\d{3,4}$", "default": "1024x1024"},
+          "model": {"type": "string", "default": "gpt-image-1"},
+          "return_b64": {"type": "boolean", "default": false},
+          "save": {
+            "type": "object",
+            "required": ["dir"],
+            "properties": {
+              "dir": {"type": "string"},
+              "basename": {"type": "string", "default": "img"},
+              "ext": {"type": "string", "enum": ["png"], "default": "png"}
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/img_create"],
+      "timeoutSec": 120,
+      "envPassthrough": ["OAI_API_KEY", "OAI_BASE_URL", "OAI_IMAGE_BASE_URL", "OAI_HTTP_TIMEOUT"]
+    }
+  ]
+}
+```
+
+Run the agent with a prompt that instructs the assistant to call `img_create` and save under `assets/`:
+
+```bash
+export OAI_BASE_URL=${OAI_BASE_URL:-https://api.openai.com/v1}
+export OAI_API_KEY=your-key
+
+./bin/agentcli \
+  -tools ./tools.json \
+  -prompt "Generate a tiny illustrative image using img_create and save it under assets/ with basename banner" \
+  -debug
+
+# Expect: one or more PNGs under assets/ (e.g., assets/banner_001.png) and a concise final message on stdout
+```
+
+Notes:
+- By default, the tool writes image files and does not include base64 in transcripts, avoiding large payloads.
+- To return base64 instead, pass `{ "return_b64": true }` to the tool; base64 is elided in stdout unless `IMG_CREATE_DEBUG_B64=1` or `DEBUG_B64=1` is set.
+- Windows: the built binary is `./tools/bin/img_create.exe` and `tools.json` should reference the `.exe`.
+- See Troubleshooting for network/API issues and timeouts: `docs/runbooks/troubleshooting.md`.
+
+#### fs_search
+```bash
+make build-tools
+mkdir -p tmp_search_demo && printf 'alpha\nbeta\ngamma\n' > tmp_search_demo/sample.txt
+jq -n '{query:"^ga",globs:["**/*.txt"],regex:true}' | ./tools/bin/fs_search | jq '.matches'
+rm -rf tmp_search_demo
+```
+
+## Security
+- Tools are an explicit allowlist from `tools.json`
+- No shell interpretation; commands executed via argv only
+- JSON contract on stdin/stdout; strict timeouts per call
+- Treat model output as untrusted input; never pass it to a shell
+
+See the full threat model in `docs/security/threat-model.md`.
+
+### Unrestricted tools warning
+- Enabling `exec` grants arbitrary command execution and may allow full network access. Treat this as remote code execution.
+- Run the CLI and tools in a sandboxed environment (container/jail/VM) with least privilege.
+- Keep `tools.json` minimal and audited. Do not pass secrets via tool arguments; prefer environment variables or CI secret stores.
+- Audit log redaction: set `GOAGENT_REDACT` to mask sensitive values in audit entries. `OAI_API_KEY`/`OPENAI_API_KEY` are always masked if present.
+
+## State persistence (-state-dir)
+
+Persist and restore execution state to make repeated runs deterministic and faster.
+
+- Enable by passing `-state-dir <dir>` (or `AGENTCLI_STATE_DIR`). The directory must be private (`0700`).
+- On first run, the CLI saves a snapshot `state-<RFC3339UTC>-<8charSHA>.json` and a pointer file `latest.json`.
+- On subsequent runs with the same scope, the CLI restores prompts/settings and skips pre-stage unless `-state-refine` is provided.
+- Partition contexts with `-state-scope` (or `AGENTCLI_STATE_SCOPE`); when unset, a default scope is derived from model, base URL, and toolset.
+- Inspect actions without touching disk using `-dry-run`.
+
+Examples:
+
+```bash
+# First run saves a snapshot
+./bin/agentcli -prompt "Say ok" -tools ./tools.json -state-dir "$PWD/.agent-state"
+
+# Restore and skip pre-stage
+./bin/agentcli -prompt "Say ok" -tools ./tools.json -state-dir "$PWD/.agent-state"
+
+# Refine existing state with inline text
+./bin/agentcli -prompt "Say ok" -state-dir "$PWD/.agent-state" -state-refine -state-refine-text "Tighten tone"
+
+# Use a custom scope to keep contexts separate
+./bin/agentcli -prompt "Say ok" -state-dir "$PWD/.agent-state" -state-scope docs-demo
+```
+
+See ADR‑0012 for rationale and details: `docs/adr/0012-state-dir-persistence.md`.
+
+## Troubleshooting
+Common issues and deterministic fixes are documented with copy‑paste commands in `docs/runbooks/troubleshooting.md`.
+
+## Documentation
+Start with the [Documentation index](docs/README.md) for design docs, ADRs, and references:
+- [Tools manifest reference](docs/reference/tools-manifest.md)
+- [Research tools reference](docs/reference/research-tools.md)
+- [CLI reference](docs/reference/cli-reference.md)
+- [Interface: code.sandbox.js.run](docs/interfaces/code.sandbox.js.run.md)
+- [Architecture: Module boundaries](docs/architecture/module-boundaries.md)
+- [Security: Threat model](docs/security/threat-model.md)
+- [ADR‑0005: Harmony pre‑processing and channel‑aware output](docs/adr/0005-harmony-pre-processing-and-channel-aware-output.md)
+- [Pre-stage Harmony output contract](docs/harmony-prestage.md)
+- [ADR‑0006: Image generation tool (img_create)](docs/adr/0006-image-generation-tool-img_create.md)
+- [ADR‑0010: Adopt SearXNG & network research toolbelt (CLI-only)](docs/adr/0010-research-tools-searxng.md)
+
+## Diagrams
+- Agent loop: `docs/diagrams/agentcli-seq.md`
+- Toolbelt interactions: `docs/diagrams/toolbelt-seq.md`
+- Pre‑stage flow: `docs/diagrams/harmony-prep-seq.md`
+
+## Tests
+Run the full test suite (offline):
+```bash
+go test ./...
+```
+Lint, vet, and formatting checks:
+```bash
+make lint
+make fmt   # apply gofmt -s -w to the repo
+```
+
+Guarded logs cleanup:
+```bash
+# Only removes ./logs when ./logs/STATE trimmed equals DOWN
+make clean-logs
+
+# End-to-end verification of the guard logic (creates temp dirs)
+make test-clean-logs
+```
+
+Reproducible builds: the `Makefile` uses `-trimpath` and stripped `-ldflags` with VCS stamping disabled so two clean builds produce identical binaries. Verify locally by running two consecutive `make clean build build-tools` and comparing `sha256sum` outputs.
+
+## Contributing
+Contributions are welcome! See `CONTRIBUTING.md` for workflow, coding standards, and how to run quality gates locally. Please also read `CODE_OF_CONDUCT.md`.
+
+Useful local helpers during development:
+- `make check-tools-paths` — enforce canonical `tools/cmd/NAME` sources and `tools/bin/NAME` invocations (requires `rg`)
+- `make verify-manifest-paths` — ensure relative `tools.json` commands use `./tools/bin/NAME` (absolute allowed in tests)
+- `make build-tool NAME=<name>` — build a single tool binary into `tools/bin/NAME`
+- `make check-go-version` — fail fast if your local Go major.minor differs from `go.mod`
+
+If your local toolchain does not match, you will see:
+```text
+Go toolchain mismatch: system X.Y != go.mod X.Y
+```
+Remediation: install the matching Go version shown by `go.mod` (e.g., from the official downloads) or switch via your version manager, then rerun `make check-go-version`.
+
+## Tooling
+
+This repository pins the toolchain for deterministic results:
+- CI uses the Go version declared in `go.mod` across all OS jobs.
+- Linting is performed with a pinned `golangci-lint` version managed by the `Makefile`.
+
+See ADR‑0003 for the full policy and rationale: [docs/adr/0003-toolchain-and-lint-policy.md](docs/adr/0003-toolchain-and-lint-policy.md).
+
+## Support
+- Open an issue on the tracker: [Issues](https://github.com/hyperifyio/goagent/issues)
+  - For security concerns, avoid posting secrets in logs. If a private report is needed, open an issue with minimal detail and a maintainer will reach out.
+ - Follow updates from the author on LinkedIn: [Jaakko Heusala](https://www.linkedin.com/in/jheusala/)
+
+## Roadmap
+Planned improvements and open ideas are tracked in `FUTURE_CHECKLIST.md`. Larger architectural decisions are recorded under `docs/adr/` (see ADR‑0001 and ADR‑0002). Contributions to the roadmap are welcome via issues and PRs.
+
+## Project status
+Experimental, but actively maintained. Interfaces may change before a stable 1.0.
+
+## License and credits
+MIT license. See `LICENSE`.
+
+Maintainers and authors:
+- Hyperify.io maintainers
+- Primary author: Jaakko Heusala
+
+Acknowledgements: inspired by OpenAI‑compatible agent patterns; built for portability and safety.
+
+## Changelog
+See `CHANGELOG.md` for notable changes and release notes.
+
+## More examples
+See `examples/unrestricted.md` for copy‑paste prompts demonstrating `exec` + file tools to write, build, and run code in a sandboxed environment.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,65 @@
+# Documentation Index
+
+This docs index helps you navigate architecture notes and diagrams.
+
+- ADR-0001: Minimal Agent CLI — design context, decisions, and contracts.
+  - Link: [docs/adr/0001-minimal-agent-cli.md](adr/0001-minimal-agent-cli.md)
+- ADR-0002: Unrestricted toolbelt (files + network) — risks, contracts, and guidance.
+  - Link: [docs/adr/0002-unrestricted-toolbelt.md](adr/0002-unrestricted-toolbelt.md)
+- ADR-0003: Toolchain & Lint Policy (Go + golangci-lint) — pin Go via go.mod and a known-good golangci-lint; CI and local workflows align.
+  - Link: [docs/adr/0003-toolchain-and-lint-policy.md](adr/0003-toolchain-and-lint-policy.md)
+- ADR-0004: Default LLM Call Policy — default temperature 1.0, capability-based omission, one-knob rule, and observability fields.
+  - Link: [docs/adr/0004-default-llm-policy.md](adr/0004-default-llm-policy.md)
+- ADR-0005: Harmony pre-processing and channel-aware output — pre-stage HTTP call, parallel read-only tools, validator/audit with stage tags, and deterministic channel routing.
+  - Link: [docs/adr/0005-harmony-pre-processing-and-channel-aware-output.md](adr/0005-harmony-pre-processing-and-channel-aware-output.md)
+ - ADR-0006: Image generation tool (img_create) — minimal Images API integration, repo‑relative saves, env passthrough, and transcript hygiene.
+   - Link: [docs/adr/0006-image-generation-tool-img_create.md](adr/0006-image-generation-tool-img_create.md)
+ - ADR-0010: Adopt SearXNG & network research toolbelt (CLI-only) — credible web discovery with provenance via SearXNG and a safe, CLI-only toolbelt.
+   - Link: [docs/adr/0010-research-tools-searxng.md](adr/0010-research-tools-searxng.md)
+ - ADR-0011: State bundle schema — versioned on-disk JSON snapshots for reproducible runs.
+   - Link: [docs/adr/0011-state-bundle-schema.md](adr/0011-state-bundle-schema.md)
+ - ADR-0012: Persist and refine execution state via -state-dir — file-based snapshots with scopes, restore-before-prep, and refinement controls.
+   - Link: [docs/adr/0012-state-dir-persistence.md](adr/0012-state-dir-persistence.md)
+- Sequence diagrams: agent flow and toolbelt interactions.
+  - Link: [docs/diagrams/agentcli-seq.md](diagrams/agentcli-seq.md)
+  - Link: [docs/diagrams/toolbelt-seq.md](diagrams/toolbelt-seq.md)
+  - Link: [docs/diagrams/harmony-prep-seq.md](diagrams/harmony-prep-seq.md)
+  - Link: [docs/diagrams/research-pipeline.md](diagrams/research-pipeline.md)
+  - Link: [docs/diagrams/prestage_flow.md](diagrams/prestage_flow.md)
+
+- Architecture: Module boundaries and allowed imports between layers.
+  - Link: [docs/architecture/module-boundaries.md](architecture/module-boundaries.md)
+
+- Tools manifest reference: precise `tools.json` schema and mapping to OpenAI tools.
+  - Link: [docs/reference/tools-manifest.md](reference/tools-manifest.md)
+ 
+ - CLI reference: complete flag list, env precedence, exit codes.
+   - Link: [docs/reference/cli-reference.md](reference/cli-reference.md)
+
+- Tool reference: Image generation tool (`img_create`).
+  - Link: [docs/reference/img_create.md](reference/img_create.md)
+- Tool reference: HTTP fetch (`http_fetch`).
+  - Link: [docs/reference/http_fetch.md](reference/http_fetch.md)
+- Tool reference: SearXNG search (`searxng_search`).
+  - Link: [docs/reference/searxng_search.md](reference/searxng_search.md)
+- Tool reference: Crossref search (`crossref_search`).
+  - Link: [docs/reference/crossref_search.md](reference/crossref_search.md)
+ - Tool reference: PDF extract (`pdf_extract`).
+   - Link: [docs/reference/pdf_extract.md](reference/pdf_extract.md)
+ - Tool reference: Wayback lookup (`wayback_lookup`).
+   - Link: [docs/reference/wayback_lookup.md](reference/wayback_lookup.md)
+
+- Security: Threat model and trust boundaries.
+  - Link: [docs/security/threat-model.md](security/threat-model.md)
+
+- Runbooks: Troubleshooting common errors and fixes.
+  - Link: [docs/runbooks/troubleshooting.md](runbooks/troubleshooting.md)
+
+- Migrations: Tools layout (legacy → canonical `tools/cmd/*` + `tools/bin/*`).
+  - Link: [docs/migrations/tools-layout.md](migrations/tools-layout.md)
+
+Additional guides will be added here as they are created.
+
+Model parameter compatibility
+
+Some reasoning-oriented models may not accept sampling parameters. The agent omits `temperature` automatically for such models while keeping the default of 1.0 for compatible families (e.g., GPT-5 variants). This avoids API errors and preserves expected defaults where applicable.

--- a/docs/adr/0001-minimal-agent-cli.md
+++ b/docs/adr/0001-minimal-agent-cli.md
@@ -1,0 +1,31 @@
+# ADR-0001 Minimal Agent CLI
+
+## Context
+We want a small, non-interactive CLI that talks to an OpenAI-compatible API (Chat Completions) and can run a small set of explicitly allowed local tools. The CLI must be vendor-agnostic and rely only on `net/http` for the API.
+
+## Options considered
+- Go vs Python vs Node: Go chosen for static binary and process control
+- SDK vs raw HTTP: raw HTTP to keep provider-agnostic
+- Streaming vs simple: no streaming in MVP
+
+## Decision
+- Implement a single-shot run loop using POST `/v1/chat/completions`
+- Tools are declared in `tools.json` with JSON Schema; invoked via argv with JSON on stdin; output is JSON on stdout
+- Per-call timeouts enforced for HTTP and tools
+
+## Consequences
+- No streaming; sequential tool execution only in MVP
+- Model/tool arguments treated as untrusted input; no shells
+
+## Contracts
+- Flags: `-prompt` (required), `-tools` (path), `-system`, `-base-url`, `-api-key`, `-model`, `-max-steps`, `-timeout`, `-temp`, `-debug`
+- Tool I/O: stdin receives raw JSON args; stdout returns single-line JSON; on error, CLI maps to `{"error":"..."}`
+
+## Issue
+Link to the canonical GitHub issue once created.
+
+## Diagram
+See `docs/diagrams/agentcli-seq.md` for the sequence diagram illustrating the loop.
+
+## Related documentation
+See the docs index at `docs/README.md` for navigation to related guides and diagrams. For the tool manifest contract, refer to `docs/reference/tools-manifest.md`.

--- a/docs/diagrams/agentcli-seq.md
+++ b/docs/diagrams/agentcli-seq.md
@@ -1,0 +1,14 @@
+```mermaid
+sequenceDiagram
+    participant CLI as agentcli
+    participant API as OpenAI-compatible API
+    participant TOOL as Local tool (get_time)
+
+    CLI->>API: POST /v1/chat/completions [system,user,tools]
+    API-->>CLI: assistant tool_calls: get_time({"tz":"Europe/Helsinki"})
+    CLI->>TOOL: exec ./tools/bin/get_time stdin {tz}
+    TOOL-->>CLI: {"tz":"...","iso":"RFC3339","unix":<sec>}
+    CLI->>API: POST /v1/chat/completions [+ tool result]
+    API-->>CLI: assistant final content
+    CLI-->>CLI: print to stdout and exit 0
+```

--- a/docs/diagrams/toolbelt-seq.md
+++ b/docs/diagrams/toolbelt-seq.md
@@ -1,0 +1,17 @@
+```mermaid
+sequenceDiagram
+    participant CLI as agentcli
+    participant API as OpenAI-compatible API
+    participant IMG as Tool (img_create)
+    participant IMGAPI as Images API
+
+    CLI->>API: POST /v1/chat/completions [system,user,tools]
+    API-->>CLI: assistant tool_calls: img_create({prompt,n,size,save:{dir,basename,ext}})
+    CLI->>IMG: exec ./tools/bin/img_create stdin JSON
+    IMG->>IMGAPI: POST /v1/images/generations {"model","prompt","n","size","response_format":"b64_json"}
+    IMGAPI-->>IMG: {b64_json}
+    IMG-->>CLI: {"saved":[{"path":"assets/img_001.png","bytes":95,"sha256":"..."}],"n":1,"size":"1024x1024","model":"gpt-image-1"}
+    CLI->>API: POST /v1/chat/completions [+ tool result]
+    API-->>CLI: assistant final content (summarizes saved file path)
+    CLI-->>CLI: print to stdout and exit 0
+```

--- a/docs/runbooks/troubleshooting.md
+++ b/docs/runbooks/troubleshooting.md
@@ -1,0 +1,292 @@
+# Troubleshooting
+
+This runbook covers common errors and deterministic fixes for `goagent`.
+
+## Troubleshooting research tools
+
+This section covers common issues for the web research toolbelt (`searxng_search`, `http_fetch`, `robots_check`, `readability_extract`, `metadata_extract`, `pdf_extract`, `rss_fetch`, `wayback_lookup`, `wiki_query`, `openalex_search`, `crossref_search`). All examples are offline-friendly except where noted; avoid real network calls in CI.
+
+### Missing environment variables
+- **`SEARXNG_BASE_URL` (required by `searxng_search`)**
+  - Symptom: stderr JSON like `{"error":"missing SEARXNG_BASE_URL"}` or bad base URL error.
+  - Fix:
+    ```bash
+    export SEARXNG_BASE_URL=http://localhost:8888
+    echo '{"q":"golang"}' | ./tools/bin/searxng_search | jq .query
+    ```
+
+- **`CROSSREF_MAILTO` (required by `crossref_search`)**
+  - Symptom: stderr JSON `{"error":"missing CROSSREF_MAILTO"}` or polite header warning/rate limit.
+  - Fix:
+    ```bash
+    export CROSSREF_MAILTO=you@example.com
+    echo '{"q":"test"}' | ./tools/bin/crossref_search | jq '.results|length'
+    ```
+
+- **`HTTP_TIMEOUT_MS` (optional global for HTTP-based tools)**
+  - Use to increase per-request timeouts deterministically for tools that support it (e.g., `http_fetch`, `searxng_search`).
+  - Example:
+    ```bash
+    export HTTP_TIMEOUT_MS=20000
+    echo '{"url":"https://example.com"}' | ./tools/bin/http_fetch | jq .status
+    ```
+
+### SSRF guard blocks request
+- Behavior: Tools that perform outbound HTTP enforce an SSRF denylist (loopback, RFC1918/4193, link-local, IPv6 ::1, DNS rebinding).
+- Symptom: stderr JSON contains an error like `SSRF_BLOCKED` or message indicating private/loopback address blocked.
+- Fix: Use only public `http`/`https` origins. If testing, run fixtures on a non-loopback address and allow only via explicit test server. Example expected block:
+  ```bash
+  echo '{"url":"http://127.0.0.1:80"}' | ./tools/bin/http_fetch || true
+  ```
+
+### HTTP 429 with Retry-After handling
+- Behavior: Tools such as `searxng_search` and some API clients retry on 429/5xx with capped attempts and will respect `Retry-After` when present.
+- Symptom: stderr JSON shows rate limit; audit logs include retry attempts.
+- Fix: Reduce query rate, honor backoff, and use authentication when available.
+  ```bash
+  # Inspect retry behavior in audit logs (example path)
+  rg -n "searxng_search" .goagent/audit || true
+  ```
+
+### Robots disallow
+- Use `robots_check` to preflight crawl permission for an origin.
+- Example:
+  ```bash
+  echo '{"url":"https://example.com/some-path","user_agent":"agentcli"}' | ./tools/bin/robots_check | jq .allowed
+  # If false, do not crawl with automated tools.
+  ```
+
+### Response truncation (max_bytes)
+- `http_fetch` enforces a hard byte cap to prevent unbounded responses.
+- Symptom: stdout JSON has `truncated:true` and possibly `body_base64` shortened.
+- Fix: Raise `max_bytes` within safe limits when needed.
+  ```bash
+  echo '{"url":"https://example.com/large","max_bytes":262144}' | ./tools/bin/http_fetch | jq .truncated
+  ```
+
+### Network timeouts
+- Symptom: stderr JSON indicates timeout or the CLI reports `context deadline exceeded`.
+- Fix: Increase tool timeout deterministically via `HTTP_TIMEOUT_MS` (for tools that support it) or tool-specific flags, and reduce payload sizes.
+  ```bash
+  export HTTP_TIMEOUT_MS=30000
+  echo '{"url":"https://example.com/slow"}' | ./tools/bin/http_fetch | jq .status || true
+  ```
+
+## Missing tool binaries
+- Symptom: `exec: "./tools/<name>": file does not exist` or tool not found in `tools.json` command path.
+- Fix:
+```bash
+# Build all tools
+make build-tools
+```
+- Build a single tool from source (post‑migration layout):
+```bash
+# Unix/macOS
+mkdir -p tools/bin
+go build -o tools/bin/fs_read_file ./tools/cmd/fs_read_file
+
+# Windows (PowerShell or cmd)
+mkdir tools\bin 2> NUL
+go build -o tools\bin\fs_read_file.exe .\tools\cmd\fs_read_file
+```
+- Verify:
+```bash
+# Unix/macOS
+./tools/bin/fs_read_file -h 2>/dev/null || echo ok
+ls -l tools/bin | grep -E 'exec|fs_'
+
+# Windows
+./tools/bin/fs_read_file.exe -h 2> NUL || echo ok
+dir tools\\bin
+```
+
+## Repo-relative path violations
+- Symptom: file tools return errors about paths outside repository or cannot find the path.
+- Fix: paths passed to fs tools must be relative to repository root. `cd` to repo root and retry.
+```bash
+# From repo root (Unix/macOS)
+echo '{"path":"README.md"}' | ./tools/bin/fs_read_file | jq .
+
+# From repo root (Windows)
+echo '{"path":"README.md"}' | ./tools/bin/fs_read_file.exe | jq .
+```
+
+## Tool timeouts
+- Symptom: `{"error":"tool timed out"}` mapped by the runner or non-zero exit due to timeout.
+- Fix: increase per-tool `timeoutSec` in `tools.json`, raise CLI `-tool-timeout` (preferred), or use a larger global `-timeout` (deprecated).
+
+### HTTP request times out (`context deadline exceeded`)
+- Cause: slow model/endpoint, proxy timeouts, or too-small `-http-timeout`.
+- Fix: increase `-http-timeout` (or set env `OAI_HTTP_TIMEOUT`), reduce prompt size/model latency, or tune proxy timeouts.
+```bash
+# Example (Unix/macOS): command that sleeps too long
+echo '{"cmd":"/bin/sleep","args":["2"],"timeoutSec":1}' | ./tools/bin/exec || true
+# Increase timeout and retry
+echo '{"cmd":"/bin/sleep","args":["1"],"timeoutSec":2}' | ./tools/bin/exec
+
+# Example (Windows): use the built binary with .exe
+echo '{"cmd":"timeout","args":["/T","2"],"timeoutSec":1}' | ./tools/bin/exec.exe || true
+echo '{"cmd":"timeout","args":["/T","1"],"timeoutSec":2}' | ./tools/bin/exec.exe
+```
+
+#### Enable HTTP retries
+- When transient, enable retries to mask brief outages and 429/5xx with backoff.
+```bash
+# Retry up to 2 times with capped backoff (Unix/macOS)
+./bin/agentcli \
+  -prompt "What's the local time in Helsinki? Use get_time." \
+  -tools ./tools.json \
+  -http-retries 2 \
+  -http-retry-backoff 500ms
+
+# Windows (PowerShell)
+./bin/agentcli.exe `
+  -prompt "What's the local time in Helsinki? Use get_time." `
+  -tools ./tools.json `
+  -http-retries 2 `
+  -http-retry-backoff 500ms
+
+# Inspect attempts in the audit log (.goagent/audit/YYYYMMDD.log)
+rg -n "http_attempt" .goagent/audit || true
+```
+
+## fs_search exclusions and file size limits
+- Behavior: `fs_search` intentionally skips known binary/output directories to keep scans fast and predictable: `.git/`, `bin/`, `logs/`, and `tools/bin/` are excluded. It also enforces a per‑file size cap of 1 MiB.
+- Symptom: expected matches inside excluded folders are not returned, or the tool exits non‑zero with a `FILE_TOO_LARGE` message.
+- Fix:
+```bash
+# Verify exclusion behavior (create a file in an excluded dir and one in a normal dir)
+mkdir -p tmp_search_demo/{bin,logs,ok}
+printf 'NEEDLE' > tmp_search_demo/bin/skip.txt
+printf 'NEEDLE' > tmp_search_demo/ok/scan.txt
+
+echo '{"query":"NEEDLE","globs":["**/*.txt"],"maxResults":10}' | ./tools/bin/fs_search | jq .
+# Expect only tmp_search_demo/ok/scan.txt to appear; files under bin/ or logs/ are skipped
+
+# Demonstrate FILE_TOO_LARGE
+python3 - <<'PY'
+from pathlib import Path
+p = Path('tmp_search_demo/ok/big.bin')
+p.write_bytes(b'A' * (1024*1024 + 1))
+print(p, p.stat().st_size)
+PY
+echo '{"query":"A","globs":["tmp_search_demo/ok/big.bin"]}' | ./tools/bin/fs_search || true
+# Expect non-zero exit and stderr JSON containing "FILE_TOO_LARGE"
+
+rm -rf tmp_search_demo
+```
+
+On Windows (PowerShell), use the `.exe` binary:
+```powershell
+New-Item -ItemType Directory -Force tmp_search_demo/bin,tmp_search_demo/logs,tmp_search_demo/ok | Out-Null
+Set-Content -NoNewline -Path tmp_search_demo/bin/skip.txt -Value NEEDLE
+Set-Content -NoNewline -Path tmp_search_demo/ok/scan.txt -Value NEEDLE
+echo '{"query":"NEEDLE","globs":["**/*.txt"],"maxResults":10}' | ./tools/bin/fs_search.exe | jq .
+
+# FILE_TOO_LARGE (PowerShell)
+python - <<'PY'
+from pathlib import Path
+p = Path('tmp_search_demo/ok/big.bin')
+p.write_bytes(b'A' * (1024*1024 + 1))
+print(p, p.stat().st_size)
+PY
+echo '{"query":"A","globs":["tmp_search_demo/ok/big.bin"]}' | ./tools/bin/fs_search.exe; if ($LASTEXITCODE -eq 0) { Write-Error 'expected non-zero' }
+Remove-Item -Recurse -Force tmp_search_demo
+```
+
+## HTTP errors to the API
+### Inspecting HTTP retry attempts
+- When retries are enabled (`-http-retries > 0`), each attempt is logged to `.goagent/audit/YYYYMMDD.log` as an `http_attempt` entry with fields `{attempt,max,status,backoffMs,endpoint}`.
+- Use this to confirm whether `Retry-After` or exponential backoff was applied and how many attempts occurred.
+
+- Symptom: non-2xx from the Chat Completions endpoint with body included.
+- Fix: ensure `OAI_BASE_URL`, `OAI_MODEL`, and `OAI_API_KEY` (if required) are set correctly.
+```bash
+# Minimal local setup example
+export OAI_BASE_URL=http://localhost:1234/v1
+export OAI_MODEL=oss-gpt-20b
+# Optional if your endpoint requires it
+export OAI_API_KEY=example-token
+
+# Quick smoke
+./scripts/smoke-test.sh || true
+```
+
+## golangci-lint not found
+- Symptom: `golangci-lint: command not found` when running `make lint`.
+- Fix:
+```bash
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+export PATH="$(go env GOPATH)/bin:$PATH"
+```
+
+## Image generation errors (img_create)
+
+- Invalid API key or missing base URL
+  - Symptom: stderr JSON like `{"error":"missing OAI_IMAGE_BASE_URL or OAI_BASE_URL"}` or API error `{"error":"unauthorized"}`.
+  - Fix:
+    ```bash
+    # Set base URL and API key (Unix/macOS)
+    export OAI_IMAGE_BASE_URL=https://api.openai.com
+    export OAI_API_KEY=sk-...
+    # Optional: fallback base if OAI_IMAGE_BASE_URL is unset
+    export OAI_BASE_URL=https://api.openai.com
+    ```
+    See reference: docs/reference/img_create.md
+
+- HTTP 429 (rate limited) or 5xx
+  - Behavior: the tool retries up to 2 times with backoff (250ms, 500ms, 1s) and then emits `{"error":"api status 429"}` or a server message if present.
+  - Fix: wait and retry; reduce parallel invocations; consider lowering `n` or image `size` to lessen load:
+    ```bash
+    echo '{"prompt":"tiny-pixel","n":1,"size":"512x512","save":{"dir":"assets"}}' | ./tools/bin/img_create || true
+    ```
+
+- Moderation/refusal or API 400 with message
+  - Behavior: non-2xx with body `{error:"..."}` or `{error:{message:"..."}}` is surfaced as that message in stderr JSON.
+  - Fix: adjust the prompt to comply with policy; verify `size` matches `^\d{3,4}x\d{3,4}$` and `n` is 1..4.
+
+- Request timeout
+  - Symptom: `{"error":"http error: context deadline exceeded"}` when the Images API is slow.
+  - Fix: increase the HTTP timeout and retry:
+    ```bash
+    export OAI_HTTP_TIMEOUT=180s
+    echo '{"prompt":"tiny-pixel","n":1,"size":"1024x1024","save":{"dir":"assets"}}' | ./tools/bin/img_create || true
+    ```
+  - If timeouts persist, try a smaller `size` or lower `n`.
+
+- Missing save.dir when not returning base64
+  - Symptom: `{"error":"save.dir is required when return_b64=false"}`.
+  - Fix: provide a repo-relative directory under `save.dir` or set `return_b64:true`:
+    ```bash
+    # Save to repo-relative assets/
+    echo '{"prompt":"tiny-pixel","save":{"dir":"assets"}}' | ./tools/bin/img_create
+
+    # Or return base64 (elided by default)
+    echo '{"prompt":"tiny-pixel","return_b64":true}' | ./tools/bin/img_create
+    ```
+
+Notes:
+- The tool only writes under the repository root and rejects absolute paths or `..` escapes.
+- By default, base64 in stdout is elided; set `IMG_CREATE_DEBUG_B64=1` (or `DEBUG_B64=1`) to include it when `return_b64=true`.
+
+## General verification
+- Run the test suite (offline):
+```bash
+go test ./...
+```
+- Rebuild CLI and tools deterministically:
+```bash
+make tidy build build-tools
+```
+
+## Invalid tool message sequencing
+- ## Pre-stage built-in tools
+- Behavior: during pre-stage, external tools from `-tools` are ignored by default. Only built-in read-only adapters are available: `fs.read_file`, `fs.list_dir`, `fs.stat`, `env.get`, `os.info`.
+- Symptom: a pre-stage `tool_calls` entry like `echo` or `exec` results in a tool message `{"error":"unknown tool: ..."}`.
+- Fix: either rely on built-ins, or explicitly enable external tools for pre-stage with `-prep-tools-allow-external` (use with caution).
+
+- Symptom: the CLI exits with an error like:
+- `error: invalid message sequence at index N: found role:"tool" without a prior assistant message containing tool_calls; each tool message must respond to an assistant tool call id`
+- or: `error: invalid message sequence at index N: role:"tool" has tool_call_id "..." that does not match any id from the most recent assistant tool_calls`
+- Cause: a tool result message was appended without a preceding assistant message that requested tool calls, or the `tool_call_id` does not match the most recent assistant `tool_calls` ids.
+- Fix: ensure the message flow strictly follows: assistant with `tool_calls[]` → one tool message per `tool_call_id` → assistant. Do not emit standalone tool messages. The CLI enforces this pre-flight and will refuse to send an invalid transcript to the API. This validator runs for both the main loop and the pre-stage (prep) call; errors during pre-stage may appear as `prep invalid message sequence`.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,46 @@
+# Threat Model
+
+This document expands on the security posture, trust boundaries, and recommended mitigations for `goagent`.
+
+## Scope
+- Non-interactive CLI (`cmd/agentcli`) that communicates with an OpenAI-compatible API and executes local tool binaries declared in `tools.json`.
+- Local tools are executed via argv only, with JSON on stdin and JSON on stdout/stderr.
+
+## Trust boundaries
+- Untrusted: model outputs, tool inputs from the model, remote API, and any data received over the network.
+- Trusted (to the extent configured): the `tools.json` manifest, local tool binaries you build and enable, and the user-provided flags/env.
+
+## Key risks and mitigations
+- Command execution risk: Tools run processes. Mitigation: explicit allowlist (`tools.json`), argv-only (no shell), minimal environment, per-call timeouts, and repo-relative file paths for fs tools. For pre-stage, external tools are disabled by default; only in-process read-only adapters are exposed unless `-prep-tools-allow-external` is set.
+- Prompt injection and tool abuse: Model may request dangerous operations. Mitigation: keep tool set minimal, prefer read-only tools (pre-stage default), and require human review for high-risk prompts. Consider running tools under containers/jails.
+- Secret leakage: Avoid printing secrets. Mitigation: supply tokens via environment or CI secrets; do not commit secrets; redaction is implemented for audit logs and tool runner so secret values are never recorded.
+- Output confusion: Tools should fail with non-zero exit and machine-readable stderr to map to `{"error": "..."}`. Mitigation: standardize tool error contracts (planned) and keep runner mapping strict.
+- Network exposure: `tools/exec.go` is unrestricted. Mitigation: enable only when necessary and document risks.
+
+## Environment variable passthrough (envPassthrough)
+
+Only an explicit allowlist of environment variables is passed from the agent to child tool processes. This minimizes ambient authority and reduces risk of accidental leakage.
+
+- Allowed keys: `OAI_API_KEY`, `OAI_BASE_URL`, `OAI_IMAGE_BASE_URL`, `OAI_HTTP_TIMEOUT`.
+- Rationale: tools that make OpenAI-compatible HTTP requests need endpoint, key, and timeout settings to operate; everything else remains isolated.
+- Redaction: audit logs and structured logs include the variable names but never their values.
+- Configuration surface: per-tool allowlist is declared in `tools.json` under `envPassthrough`; the runner builds the child environment as `PATH,HOME` plus only those keys if present in the parent process.
+
+## Tool privacy: img_create
+
+The `img_create` tool interacts with the Images API and may handle large base64 payloads. Privacy and transcript hygiene are enforced by default:
+
+- Prompts and base64 image data are not logged in audit logs or human-readable output by default. When returning base64 to the agent, the tool emits a hint that content was elided unless an explicit debug flag is enabled.
+- When saving images, files are written only under a repository-relative `save.dir` path that must resolve inside the current repo; path traversal and escapes are rejected.
+- Standardized stderr JSON is used for errors, avoiding accidental leakage through free-form logs.
+
+## Operational guidance
+- Run the CLI in a working directory with restricted permissions.
+- Review `tools.json` before enabling tools; prefer least privilege.
+- Use containers or separate user namespaces to isolate untrusted tools.
+- Configure `OAI_API_KEY` via env; never commit credentials.
+
+## References
+- See `README.md` Security model for a quick summary.
+- ADR-0001 documents the CLI architecture and contracts.
+ - Research tools security posture and guardrails: see [security/research-tools.md](research-tools.md)


### PR DESCRIPTION
Adds ADR-0001, diagrams for agent flow and toolbelt, security threat model, troubleshooting runbook, and docs/README index. Updates top-level README links. Scope limited to documentation; no code or tests. References FEATURE_CHECKLIST.md and CHANGELOG.md tracking items.