### PR TITLE
Tools: manifest loader (+ tests, docs)

### DIFF
--- a/docs/reference/tools-manifest.md
+++ b/docs/reference/tools-manifest.md
@@ -1,0 +1,93 @@
+# Tools Manifest Reference (tools.json)
+
+This page documents the `tools.json` schema consumed by `agentcli` and how it is translated into OpenAI-compatible tool definitions. It reflects the current implementation in `internal/tools/manifest.go` and the unit tests in `internal/tools/manifest_test.go`.
+
+## Schema
+
+Root object:
+```json
+{
+  "tools": [ ToolSpec, ... ]
+}
+```
+
+ToolSpec fields:
+- `name` (string, required): Unique tool name. Must be non-empty and unique across the manifest.
+- `description` (string, optional): Short human description.
+- `schema` (object, optional): JSON Schema for the tool parameters. This is passed through to the model as `parameters` in the OpenAI "function" tool.
+- `command` (array of string, required): Argv vector. First element is the program path (relative or absolute); subsequent elements are fixed args. When relative, it MUST start with `./tools/bin/NAME` (use `.exe` on Windows). Relative paths are resolved against the directory containing this `tools.json` (not the process working directory). The runner will execute this program and write the function call JSON arguments to stdin.
+- `timeoutSec` (integer, optional): Per-call timeout override in seconds. If omitted, the CLI's `-timeout` applies.
+- `envPassthrough` (array of string, optional): Allowlist of environment variable names to pass from the parent process to the tool. Names are normalized to uppercase and must match the regex `[A-Z_][A-Z0-9_]*`. Duplicates are removed preserving first occurrence. The runner always sets a minimal base environment (e.g., `PATH`, `HOME`) and augments it with only these keys if present in the parent. For observability, the audit log records only the names of keys passed (as `envKeys`), never their values.
+
+Notes:
+- Validation errors are precise and include the offending index/name.
+- `command` must have at least one element (the program).
+- Names must be unique (duplicates are rejected).
+
+## OpenAI tool mapping
+Each manifest entry is exported as an OpenAI tool of type `function`:
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "<name>",
+    "description": "<description>",
+    "parameters": { /* schema as provided */ }
+  }
+}
+```
+
+## Minimal example
+```json
+{
+  "tools": [
+    {
+      "name": "get_time",
+      "description": "Get current time for an IANA timezone",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "timezone": {"type": "string", "description": "IANA timezone, e.g. Europe/Helsinki"},
+          "tz": {"type": "string", "description": "Alias for timezone (deprecated)"}
+        },
+        "required": ["timezone"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/get_time"],
+      "timeoutSec": 5,
+      "envPassthrough": ["TZ", "OAI_HTTP_TIMEOUT"]
+    }
+  ]
+}
+```
+
+On Windows, use the `.exe` suffix for the tool binary:
+
+```json
+{
+  "tools": [
+    {
+      "name": "get_time",
+      "schema": {"type":"object","properties":{"timezone":{"type":"string"}},"required":["timezone"],"additionalProperties":false},
+      "command": ["./tools/bin/get_time.exe"],
+      "timeoutSec": 5
+    }
+  ]
+}
+```
+
+## Common mistakes
+- Missing `name`: error `tool[i]: name is required`.
+- Duplicate `name`: error `tool[i] "<name>": duplicate name`.
+- Empty `command`: error `tool[i] "<name>": command must have at least program name`.
+- Relative `command[0]` not using the canonical bin prefix: error `tool[i] "<name>": relative command[0] must start with ./tools/bin/` (absolute paths are allowed for tests). This ensures tools are invoked from `./tools/bin/NAME` and are then resolved relative to the manifest directory.
+- Relative `command[0]` that normalizes to escape the tools bin directory (e.g., `./tools/bin/../hack`): error `tool[i] "<name>": command[0] escapes ./tools/bin after normalization (got "./tools/bin/../hack" -> "./tools/hack")`.
+- Invalid `envPassthrough` entry (e.g., `"OAI-API-KEY"` or `"1BAD"`): error `tool[i] "<name>": envPassthrough[j]: invalid name "..." (must match [A-Z_][A-Z0-9_]*)`.
+
+## Execution model
+- The assistant provides JSON arguments for the tool call. `agentcli` passes that JSON to the tool's stdin verbatim.
+- Tools must print a single-line JSON result to stdout. On failure, print a single-line JSON error to stderr and exit non-zero. The agent maps failures to `{"error":"..."}` content for the model.
+- Environment is scrubbed to a minimal allowlist (PATH, HOME) and optionally augmented by `envPassthrough`. No shell is invoked; commands are executed via argv.
+
+## Versioning
+This document describes the current stable behavior. Backward-incompatible changes will be documented in the changelog and ADRs.

--- a/internal/tools/manifest.go
+++ b/internal/tools/manifest.go
@@ -1,0 +1,165 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/hyperifyio/goagent/internal/oai"
+)
+
+type ToolSpec struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Schema      json.RawMessage `json:"schema,omitempty"` // JSON Schema for params
+	Command     []string        `json:"command"`          // argv: program and args
+	TimeoutSec  int             `json:"timeoutSec,omitempty"`
+	// EnvPassthrough is an allowlist of environment variable names that may be
+	// passed through from the parent process to the tool process. Names are
+	// normalized to upper case, trimmed, validated against [A-Z_][A-Z0-9_]*,
+	// and de-duplicated while preserving order.
+	EnvPassthrough []string `json:"envPassthrough,omitempty"`
+}
+
+type Manifest struct {
+	Tools []ToolSpec `json:"tools"`
+}
+
+// LoadManifest reads tools.json and returns a name->spec registry and an OpenAI-compatible tools array.
+// Relative command paths in the manifest are validated and then resolved relative to the manifest's directory,
+// so they do not depend on the process working directory.
+func LoadManifest(manifestPath string) (map[string]ToolSpec, []oai.Tool, error) {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read manifest: %w", err)
+	}
+	var man Manifest
+	if err := json.Unmarshal(data, &man); err != nil {
+		return nil, nil, fmt.Errorf("parse manifest: %w", err)
+	}
+	registry := make(map[string]ToolSpec)
+	var oaiTools []oai.Tool
+	nameSeen := make(map[string]struct{})
+	manifestDir := filepath.Dir(manifestPath)
+	for i, t := range man.Tools {
+		if t.Name == "" {
+			return nil, nil, fmt.Errorf("tool[%d]: name is required", i)
+		}
+		if _, ok := nameSeen[t.Name]; ok {
+			return nil, nil, fmt.Errorf("tool[%d] %q: duplicate name", i, t.Name)
+		}
+		nameSeen[t.Name] = struct{}{}
+		if len(t.Command) < 1 {
+			return nil, nil, fmt.Errorf("tool[%d] %q: command must have at least program name", i, t.Name)
+		}
+		// Validate and normalize envPassthrough early so callers can rely on it
+		if len(t.EnvPassthrough) > 0 {
+			norm, err := normalizeEnvAllowlist(t.EnvPassthrough)
+			if err != nil {
+				return nil, nil, fmt.Errorf("tool[%d] %q: %v", i, t.Name, err)
+			}
+			t.EnvPassthrough = norm
+		}
+		// S52/S30: Harden command[0] validation. For any relative program path,
+		// enforce the canonical tools bin prefix and prevent path escapes.
+		cmd0 := t.Command[0]
+		if !filepath.IsAbs(cmd0) {
+			// Normalize separators: convert backslashes to slashes (works cross‑platform)
+			// and then perform a platform-agnostic clean. Finally, ensure forward slashes.
+			raw := strings.ReplaceAll(cmd0, "\\", "/")
+			norm := filepath.ToSlash(path.Clean(raw))
+			// Normalize to a consistent leading ./ for prefix checks
+			if strings.HasPrefix(norm, "tools/") || norm == "tools" {
+				norm = "./" + norm
+			}
+			// Reject leading parent traversal
+			if strings.HasPrefix(norm, "../") || norm == ".." {
+				return nil, nil, fmt.Errorf("tool[%d] %q: command[0] must not start with '..' or escape tools/bin (got %q)", i, t.Name, cmd0)
+			}
+			// If original referenced ./tools/bin, ensure cleaned still stays within ./tools/bin
+			if strings.HasPrefix(raw, "./tools/bin/") || raw == "./tools/bin" {
+				if !(strings.HasPrefix(norm, "./tools/bin/")) {
+					return nil, nil, fmt.Errorf("tool[%d] %q: command[0] escapes ./tools/bin after normalization (got %q -> %q)", i, t.Name, cmd0, norm)
+				}
+			} else {
+				// Enforce canonical prefix for all other relative commands
+				if !strings.HasPrefix(norm, "./tools/bin/") {
+					return nil, nil, fmt.Errorf("tool[%d] %q: relative command[0] must start with ./tools/bin/", i, t.Name)
+				}
+			}
+			// Resolve relative program path against the manifest directory to avoid dependence on process CWD
+			// Keep validation based on the normalized forward-slash path, but compute a concrete absolute filesystem path.
+			// Example: manifest in /repo/sub/manifest/tools.json and command "./tools/bin/name" -> /repo/sub/manifest/tools/bin/name
+			// Trim leading "./" for joining, then convert to OS-specific separators.
+			trimmed := strings.TrimPrefix(norm, "./")
+			resolved := filepath.Join(manifestDir, filepath.FromSlash(trimmed))
+			absResolved, errAbs := filepath.Abs(resolved)
+			if errAbs != nil {
+				return nil, nil, fmt.Errorf("tool[%d] %q: resolve command[0]: %v", i, t.Name, errAbs)
+			}
+			t.Command[0] = absResolved
+		}
+		registry[t.Name] = t
+		// Build OpenAI tools entry
+		entry := oai.Tool{
+			Type: "function",
+			Function: oai.ToolFunction{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  t.Schema,
+			},
+		}
+		oaiTools = append(oaiTools, entry)
+	}
+	return registry, oaiTools, nil
+}
+
+// normalizeEnvAllowlist normalizes, validates, and de-duplicates environment
+// variable names. It enforces the pattern ^[A-Z_][A-Z0-9_]*$ after converting
+// to upper case and trimming ASCII whitespace. Order of first occurrence is
+// preserved. Returns an error describing the first invalid entry.
+func normalizeEnvAllowlist(keys []string) ([]string, error) {
+	out := make([]string, 0, len(keys))
+	seen := make(map[string]struct{}, len(keys))
+	for idx, k := range keys {
+		// Treat empty and whitespace-only as invalid
+		trimmed := strings.TrimSpace(k)
+		if trimmed == "" {
+			return nil, fmt.Errorf("envPassthrough[%d]: empty name", idx)
+		}
+		upper := strings.ToUpper(trimmed)
+		// Validate against a strict env var name pattern
+		// First character: A-Z or _
+		// Subsequent: A-Z, 0-9, _
+		if !isValidEnvName(upper) {
+			return nil, fmt.Errorf("envPassthrough[%d]: invalid name %q (must match [A-Z_][A-Z0-9_]*)", idx, k)
+		}
+		if _, ok := seen[upper]; ok {
+			continue
+		}
+		seen[upper] = struct{}{}
+		out = append(out, upper)
+	}
+	return out, nil
+}
+
+func isValidEnvName(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	// First rune must be A-Z or _
+	c := s[0]
+	if !((c >= 'A' && c <= 'Z') || c == '_') {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		c = s[i]
+		if !((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tools/manifest_test.go
+++ b/internal/tools/manifest_test.go
@@ -1,0 +1,237 @@
+package tools
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// https://github.com/hyperifyio/goagent/issues/1
+func TestLoadManifest_OK(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "tools.json")
+	data := map[string]any{
+		"tools": []map[string]any{
+			{
+				"name":        "hello",
+				"description": "says hello",
+				"schema":      map[string]any{"type": "object"},
+				// absolute path allowed in tests
+				"command": []string{"/bin/echo", "{}"},
+				// envPassthrough should be normalized, deduplicated
+				"envPassthrough": []string{"oai_api_key", "OAI_API_KEY", " Path ", "TZ"},
+			},
+		},
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(file, b, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	reg, tools, err := LoadManifest(file)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(reg) != 1 || len(tools) != 1 {
+		t.Fatalf("unexpected sizes: reg=%d tools=%d", len(reg), len(tools))
+	}
+	spec := reg["hello"]
+	want := []string{"OAI_API_KEY", "PATH", "TZ"}
+	if len(spec.EnvPassthrough) != len(want) {
+		t.Fatalf("envPassthrough len: got %d want %d", len(spec.EnvPassthrough), len(want))
+	}
+	for i := range want {
+		if spec.EnvPassthrough[i] != want[i] {
+			t.Fatalf("envPassthrough[%d]: got %q want %q", i, spec.EnvPassthrough[i], want[i])
+		}
+	}
+}
+
+func TestLoadManifest_DuplicateName(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "tools.json")
+	data := `{"tools":[{"name":"x","command":["echo","{}"]},{"name":"x","command":["echo","{}"]}]}`
+	if err := os.WriteFile(file, []byte(data), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, _, err := LoadManifest(file)
+	if err == nil {
+		t.Fatalf("expected error for duplicate names")
+	}
+}
+
+// https://github.com/hyperifyio/goagent/issues/1
+func TestLoadManifest_MissingNameOrCommand(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "tools.json")
+	// Missing name
+	data := `{"tools":[{"description":"x","command":["echo","{}"]}]}`
+	if err := os.WriteFile(file, []byte(data), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := LoadManifest(file); err == nil {
+		t.Fatalf("expected error for missing name")
+	}
+
+	// Missing command
+	data = `{"tools":[{"name":"x"}]}`
+	if err := os.WriteFile(file, []byte(data), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := LoadManifest(file); err == nil {
+		t.Fatalf("expected error for missing command")
+	}
+}
+
+// Harden validation: reject relative command[0] that escapes ./tools/bin or contains .. after normalization
+func TestLoadManifest_CommandEscapeAndDotDot(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "tools.json")
+
+	cases := []struct {
+		name     string
+		command0 string
+		wantErr  bool
+	}{
+		{name: "ok-absolute", command0: "/usr/bin/env", wantErr: false},
+		// relative simple path must now be under ./tools/bin
+		{name: "reject-simple-relative", command0: "echo", wantErr: true},
+		{name: "ok-tools-bin", command0: "./tools/bin/fs_read_file", wantErr: false},
+		{name: "reject-dotdot-leading", command0: "../tools/bin/get_time", wantErr: true},
+		{name: "reject-escape-from-bin", command0: "./tools/bin/../hack", wantErr: true},
+		// Windows-style backslashes that normalize to an escape must be rejected
+		{name: "reject-windows-backslash-escape", command0: ".\\tools\\bin\\..\\hack", wantErr: true},
+		// Windows-style acceptable path under tools/bin should be accepted after normalization
+		{name: "ok-windows-backslash-tools-bin", command0: ".\\tools\\bin\\fs_read_file", wantErr: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := map[string]any{
+				"tools": []map[string]any{
+					{
+						"name":    "t",
+						"command": []string{tc.command0},
+					},
+				},
+			}
+			b, err2 := json.Marshal(data)
+			if err2 != nil {
+				t.Fatalf("marshal: %v", err2)
+			}
+			if err := os.WriteFile(file, b, 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			_, _, err := LoadManifest(file)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for command0=%q", tc.command0)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.command0, err)
+			}
+		})
+	}
+}
+
+func TestLoadManifest_InvalidEnvPassthrough(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "tools.json")
+	// Invalid names: leading digit and dash inside
+	data := map[string]any{
+		"tools": []map[string]any{
+			{
+				"name":           "t",
+				"command":        []string{"/bin/true"},
+				"envPassthrough": []string{"1BAD", "GOOD", "OAI-API-KEY"},
+			},
+		},
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(file, b, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := LoadManifest(file); err == nil {
+		t.Fatalf("expected error for invalid envPassthrough entries")
+	}
+}
+
+// Relative command paths must resolve against the manifest directory, not process CWD.
+// The loader should rewrite command[0] to an absolute path rooted at the manifest's folder.
+func TestLoadManifest_ResolvesRelativeAgainstManifestDir(t *testing.T) {
+	// Create nested manifest directory
+	base := t.TempDir()
+	nested := filepath.Join(base, "configs", "sub")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	// Create a fake tools/bin tree relative to the manifest
+	binDir := filepath.Join(nested, "tools", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	// Create a small executable file to represent the tool binary
+	toolPath := filepath.Join(binDir, "hello_tool")
+	if err := os.WriteFile(toolPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write tool bin: %v", err)
+	}
+	// Write manifest that references ./tools/bin/hello_tool relative to the manifest dir
+	manPath := filepath.Join(nested, "tools.json")
+	data := map[string]any{
+		"tools": []map[string]any{
+			{
+				"name":    "hello",
+				"command": []string{"./tools/bin/hello_tool"},
+			},
+		},
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(manPath, b, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	// Change working directory to a different location to ensure CWD is not used for resolution
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	other := filepath.Join(base, "other")
+	if err := os.MkdirAll(other, 0o755); err != nil {
+		t.Fatalf("mkdir other: %v", err)
+	}
+	if err := os.Chdir(other); err != nil {
+		t.Fatalf("chdir other: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWD); err != nil {
+			t.Logf("chdir restore: %v", err)
+		}
+	})
+
+	reg, _, err := LoadManifest(manPath)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	spec, ok := reg["hello"]
+	if !ok {
+		t.Fatalf("missing tool in registry")
+	}
+	if len(spec.Command) == 0 {
+		t.Fatalf("empty command")
+	}
+	got := spec.Command[0]
+	if !filepath.IsAbs(got) {
+		t.Fatalf("command[0] not absolute: %q", got)
+	}
+	// It should point to the tool under the manifest's directory, not under CWD
+	if got != toolPath {
+		t.Fatalf("resolved path mismatch:\n got: %s\nwant: %s", got, toolPath)
+	}
+}


### PR DESCRIPTION
## Scope
- Add manifest loader in `internal/tools/manifest.go` with validation
- Include `internal/tools/manifest_test.go`
- Add `docs/reference/tools-manifest.md`

## Risk
Low; focused on manifest parsing and validation.

## Tests
- `go test ./internal/tools -run Manifest` passes locally

Tracked in `FEATURE_CHECKLIST.md` (PR #06).