### PR TITLE
Tools runner: argv-only execution with audit logs

### DIFF
--- a/internal/tools/runner.go
+++ b/internal/tools/runner.go
@@ -1,17 +1,12 @@
 package tools
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"time"
+    "context"
+    "errors"
+    "fmt"
+    "os"
+    "os/exec"
+    "time"
 )
 
 // RunToolWithJSON executes the tool command with args JSON provided on stdin.
@@ -113,11 +108,11 @@ func RunToolWithJSON(parentCtx context.Context, spec ToolSpec, jsonInput []byte,
 		}
 	}
 
-	// Read stdout and stderr fully
-	outCh := make(chan []byte, 1)
-	errCh := make(chan []byte, 1)
-	go func() { outCh <- safeReadAll(stdout) }()
-	go func() { errCh <- safeReadAll(stderr) }()
+    // Read stdout and stderr fully
+    outCh := make(chan []byte, 1)
+    errCh := make(chan []byte, 1)
+    go func() { outCh <- safeReadAll(stdout) }()
+    go func() { errCh <- safeReadAll(stderr) }()
 
 	err = cmd.Wait()
 	out := <-outCh
@@ -133,176 +128,11 @@ func RunToolWithJSON(parentCtx context.Context, spec ToolSpec, jsonInput []byte,
 			exitCode = -1
 		}
 	}
-	// Best-effort audit (failures do not affect tool result)
-	writeAudit(spec, start, exitCode, len(out), len(serr), passedKeys)
+    // Best-effort audit (failures do not affect tool result)
+    writeAudit(spec, start, exitCode, len(out), len(serr), passedKeys)
 
 	if normErr := normalizeWaitError(ctx, err, string(serr)); normErr != nil {
 		return nil, normErr
 	}
 	return out, nil
-}
-
-// safeReadAll reads all bytes from r; on error it returns any bytes read so far (or nil).
-func safeReadAll(r io.Reader) []byte {
-	b, err := io.ReadAll(r)
-	if err != nil {
-		return b
-	}
-	return b
-}
-
-// writeAudit emits an NDJSON line capturing tool execution metadata.
-func writeAudit(spec ToolSpec, start time.Time, exitCode, stdoutBytes, stderrBytes int, envKeys []string) {
-	type auditEntry struct {
-		TS          string   `json:"ts"`
-		Tool        string   `json:"tool"`
-		Argv        []string `json:"argv"`
-		CWD         string   `json:"cwd"`
-		Exit        int      `json:"exit"`
-		MS          int64    `json:"ms"`
-		StdoutBytes int      `json:"stdoutBytes"`
-		StderrBytes int      `json:"stderrBytes"`
-		Truncated   bool     `json:"truncated"`
-		EnvKeys     []string `json:"envKeys,omitempty"`
-	}
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		cwd = ""
-	}
-	entry := auditEntry{
-		TS:          timeNow().UTC().Format(time.RFC3339Nano),
-		Tool:        spec.Name,
-		Argv:        redactSensitiveStrings(append([]string(nil), spec.Command...)),
-		CWD:         redactSensitiveString(cwd),
-		Exit:        exitCode,
-		MS:          time.Since(start).Milliseconds(),
-		StdoutBytes: stdoutBytes,
-		StderrBytes: stderrBytes,
-		Truncated:   false,
-		EnvKeys:     append([]string(nil), envKeys...),
-	}
-	if err := appendAuditLog(entry); err != nil {
-		_ = err
-	}
-}
-
-// appendAuditLog writes an NDJSON audit line to .goagent/audit/YYYYMMDD.log under the repository root.
-// The repository root is determined by walking upward from the current working directory
-// until a directory containing go.mod is found. If no go.mod is found, falls back to CWD.
-func appendAuditLog(entry any) error {
-	b, err := json.Marshal(entry)
-	if err != nil {
-		return err
-	}
-	root := moduleRoot()
-	dir := filepath.Join(root, ".goagent", "audit")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
-	}
-	fname := timeNow().UTC().Format("20060102") + ".log"
-	path := filepath.Join(dir, fname)
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := f.Close(); err != nil {
-			_ = err
-		}
-	}()
-	if _, err := f.Write(append(b, '\n')); err != nil {
-		return err
-	}
-	return nil
-}
-
-// moduleRoot walks upward from the current working directory to locate the directory
-// containing go.mod. If none is found, it returns the current working directory.
-func moduleRoot() string {
-	cwd, err := os.Getwd()
-	if err != nil || cwd == "" {
-		return "."
-	}
-	dir := cwd
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			// Reached filesystem root; fallback to original cwd
-			return cwd
-		}
-		dir = parent
-	}
-}
-
-// redactSensitiveStrings applies redactSensitiveString to each element and returns a new slice.
-func redactSensitiveStrings(values []string) []string {
-	out := make([]string, len(values))
-	for i, v := range values {
-		out[i] = redactSensitiveString(v)
-	}
-	return out
-}
-
-// redactSensitiveString masks occurrences of configured sensitive patterns and known secret env values.
-// Patterns are sourced from GOAGENT_REDACT (comma/semicolon-separated substrings or regexes).
-// Additionally, values of well-known secret env vars (OAI_API_KEY, OPENAI_API_KEY) are masked if present.
-func redactSensitiveString(s string) string {
-	if s == "" {
-		return s
-	}
-	// Collect patterns
-	patterns := gatherRedactionPatterns()
-	// Apply regex replacements first
-	for _, rx := range patterns.regexps {
-		s = rx.ReplaceAllString(s, "***REDACTED***")
-	}
-	// Apply literal value masking
-	for _, lit := range patterns.literals {
-		if lit == "" {
-			continue
-		}
-		s = strings.ReplaceAll(s, lit, "***REDACTED***")
-	}
-	return s
-}
-
-type redactionPatterns struct {
-	regexps  []*regexp.Regexp
-	literals []string
-}
-
-// gatherRedactionPatterns builds redaction patterns from environment.
-// GOAGENT_REDACT may contain comma/semicolon separated regex patterns or literals.
-// Known secret env values are added as literal masks.
-func gatherRedactionPatterns() redactionPatterns {
-	var pats redactionPatterns
-	// Configurable patterns
-	cfg := os.Getenv("GOAGENT_REDACT")
-	if cfg != "" {
-		// split by comma or semicolon
-		fields := strings.FieldsFunc(cfg, func(r rune) bool { return r == ',' || r == ';' })
-		for _, f := range fields {
-			f = strings.TrimSpace(f)
-			if f == "" {
-				continue
-			}
-			// Try to compile as regex; if it fails, treat as literal
-			if rx, err := regexp.Compile(f); err == nil {
-				pats.regexps = append(pats.regexps, rx)
-			} else {
-				pats.literals = append(pats.literals, f)
-			}
-		}
-	}
-	// Known secret env values (mask exact substrings)
-	for _, key := range []string{"OAI_API_KEY", "OPENAI_API_KEY"} {
-		if v := os.Getenv(key); v != "" {
-			pats.literals = append(pats.literals, v)
-		}
-	}
-	return pats
 }

--- a/internal/tools/runner.go
+++ b/internal/tools/runner.go
@@ -1,0 +1,308 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// RunToolWithJSON executes the tool command with args JSON provided on stdin.
+// Returns stdout bytes and an error if the command fails. The caller is responsible
+// for mapping errors to deterministic JSON per product rules.
+// timeNow is a package-level clock to enable deterministic tests.
+// In production it defaults to time.Now.
+var timeNow = time.Now
+
+// computeToolTimeout derives the timeout for a tool execution, honoring
+// spec.TimeoutSec when provided; otherwise it falls back to the default.
+func computeToolTimeout(spec ToolSpec, defaultTimeout time.Duration) time.Duration {
+	if spec.TimeoutSec > 0 {
+		return time.Duration(spec.TimeoutSec) * time.Second
+	}
+	return defaultTimeout
+}
+
+// buildToolEnvironment constructs a minimal environment for the tool process
+// and returns the environment slice along with the list of env keys that were
+// passed through (for audit visibility).
+func buildToolEnvironment(spec ToolSpec) (env []string, passedKeys []string) {
+	if v := os.Getenv("PATH"); v != "" {
+		env = append(env, "PATH="+v)
+	}
+	if v := os.Getenv("HOME"); v != "" {
+		env = append(env, "HOME="+v)
+	}
+	if len(spec.EnvPassthrough) > 0 {
+		for _, key := range spec.EnvPassthrough {
+			if val, ok := os.LookupEnv(key); ok {
+				env = append(env, key+"="+val)
+				passedKeys = append(passedKeys, key)
+			}
+		}
+	}
+	return env, passedKeys
+}
+
+// normalizeWaitError maps timeout and process errors to deterministic errors.
+func normalizeWaitError(ctx context.Context, waitErr error, stderrText string) error {
+	if ctx.Err() == context.DeadlineExceeded {
+		return errors.New("tool timed out")
+	}
+	if waitErr != nil {
+		msg := stderrText
+		if msg == "" {
+			msg = waitErr.Error()
+		}
+		return errors.New(msg)
+	}
+	return nil
+}
+
+func RunToolWithJSON(parentCtx context.Context, spec ToolSpec, jsonInput []byte, defaultTimeout time.Duration) ([]byte, error) {
+	start := time.Now()
+	// Derive timeout, honoring per-tool override when provided.
+	to := computeToolTimeout(spec, defaultTimeout)
+	ctx, cancel := context.WithTimeout(parentCtx, to)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, spec.Command[0], spec.Command[1:]...)
+	// Build minimal environment and record passed-through keys for audit.
+	env, passedKeys := buildToolEnvironment(spec)
+	cmd.Env = env
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start: %w", err)
+	}
+	// Write JSON to stdin
+	if len(jsonInput) == 0 {
+		jsonInput = []byte("{}")
+	}
+	if _, err := stdin.Write(jsonInput); err != nil {
+		return nil, fmt.Errorf("write stdin: %w", err)
+	}
+	// Best-effort close; log failure to audit but do not fail run
+	if err := stdin.Close(); err != nil {
+		// Capture the close error as a best-effort audit line
+		if err2 := appendAuditLog(map[string]any{
+			"ts":    timeNow().UTC().Format(time.RFC3339Nano),
+			"event": "stdin_close_error",
+			"tool":  spec.Name,
+			"error": err.Error(),
+		}); err2 != nil {
+			_ = err2
+		}
+	}
+
+	// Read stdout and stderr fully
+	outCh := make(chan []byte, 1)
+	errCh := make(chan []byte, 1)
+	go func() { outCh <- safeReadAll(stdout) }()
+	go func() { errCh <- safeReadAll(stderr) }()
+
+	err = cmd.Wait()
+	out := <-outCh
+	serr := <-errCh
+
+	exitCode := 0
+	if err != nil {
+		// Try to capture exit code when available
+		if ee, ok := err.(*exec.ExitError); ok && ee.ProcessState != nil {
+			exitCode = ee.ProcessState.ExitCode()
+		} else {
+			// Unknown exit (e.g., timeout/cancel)
+			exitCode = -1
+		}
+	}
+	// Best-effort audit (failures do not affect tool result)
+	writeAudit(spec, start, exitCode, len(out), len(serr), passedKeys)
+
+	if normErr := normalizeWaitError(ctx, err, string(serr)); normErr != nil {
+		return nil, normErr
+	}
+	return out, nil
+}
+
+// safeReadAll reads all bytes from r; on error it returns any bytes read so far (or nil).
+func safeReadAll(r io.Reader) []byte {
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return b
+	}
+	return b
+}
+
+// writeAudit emits an NDJSON line capturing tool execution metadata.
+func writeAudit(spec ToolSpec, start time.Time, exitCode, stdoutBytes, stderrBytes int, envKeys []string) {
+	type auditEntry struct {
+		TS          string   `json:"ts"`
+		Tool        string   `json:"tool"`
+		Argv        []string `json:"argv"`
+		CWD         string   `json:"cwd"`
+		Exit        int      `json:"exit"`
+		MS          int64    `json:"ms"`
+		StdoutBytes int      `json:"stdoutBytes"`
+		StderrBytes int      `json:"stderrBytes"`
+		Truncated   bool     `json:"truncated"`
+		EnvKeys     []string `json:"envKeys,omitempty"`
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = ""
+	}
+	entry := auditEntry{
+		TS:          timeNow().UTC().Format(time.RFC3339Nano),
+		Tool:        spec.Name,
+		Argv:        redactSensitiveStrings(append([]string(nil), spec.Command...)),
+		CWD:         redactSensitiveString(cwd),
+		Exit:        exitCode,
+		MS:          time.Since(start).Milliseconds(),
+		StdoutBytes: stdoutBytes,
+		StderrBytes: stderrBytes,
+		Truncated:   false,
+		EnvKeys:     append([]string(nil), envKeys...),
+	}
+	if err := appendAuditLog(entry); err != nil {
+		_ = err
+	}
+}
+
+// appendAuditLog writes an NDJSON audit line to .goagent/audit/YYYYMMDD.log under the repository root.
+// The repository root is determined by walking upward from the current working directory
+// until a directory containing go.mod is found. If no go.mod is found, falls back to CWD.
+func appendAuditLog(entry any) error {
+	b, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	root := moduleRoot()
+	dir := filepath.Join(root, ".goagent", "audit")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	fname := timeNow().UTC().Format("20060102") + ".log"
+	path := filepath.Join(dir, fname)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			_ = err
+		}
+	}()
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+// moduleRoot walks upward from the current working directory to locate the directory
+// containing go.mod. If none is found, it returns the current working directory.
+func moduleRoot() string {
+	cwd, err := os.Getwd()
+	if err != nil || cwd == "" {
+		return "."
+	}
+	dir := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Reached filesystem root; fallback to original cwd
+			return cwd
+		}
+		dir = parent
+	}
+}
+
+// redactSensitiveStrings applies redactSensitiveString to each element and returns a new slice.
+func redactSensitiveStrings(values []string) []string {
+	out := make([]string, len(values))
+	for i, v := range values {
+		out[i] = redactSensitiveString(v)
+	}
+	return out
+}
+
+// redactSensitiveString masks occurrences of configured sensitive patterns and known secret env values.
+// Patterns are sourced from GOAGENT_REDACT (comma/semicolon-separated substrings or regexes).
+// Additionally, values of well-known secret env vars (OAI_API_KEY, OPENAI_API_KEY) are masked if present.
+func redactSensitiveString(s string) string {
+	if s == "" {
+		return s
+	}
+	// Collect patterns
+	patterns := gatherRedactionPatterns()
+	// Apply regex replacements first
+	for _, rx := range patterns.regexps {
+		s = rx.ReplaceAllString(s, "***REDACTED***")
+	}
+	// Apply literal value masking
+	for _, lit := range patterns.literals {
+		if lit == "" {
+			continue
+		}
+		s = strings.ReplaceAll(s, lit, "***REDACTED***")
+	}
+	return s
+}
+
+type redactionPatterns struct {
+	regexps  []*regexp.Regexp
+	literals []string
+}
+
+// gatherRedactionPatterns builds redaction patterns from environment.
+// GOAGENT_REDACT may contain comma/semicolon separated regex patterns or literals.
+// Known secret env values are added as literal masks.
+func gatherRedactionPatterns() redactionPatterns {
+	var pats redactionPatterns
+	// Configurable patterns
+	cfg := os.Getenv("GOAGENT_REDACT")
+	if cfg != "" {
+		// split by comma or semicolon
+		fields := strings.FieldsFunc(cfg, func(r rune) bool { return r == ',' || r == ';' })
+		for _, f := range fields {
+			f = strings.TrimSpace(f)
+			if f == "" {
+				continue
+			}
+			// Try to compile as regex; if it fails, treat as literal
+			if rx, err := regexp.Compile(f); err == nil {
+				pats.regexps = append(pats.regexps, rx)
+			} else {
+				pats.literals = append(pats.literals, f)
+			}
+		}
+	}
+	// Known secret env values (mask exact substrings)
+	for _, key := range []string{"OAI_API_KEY", "OPENAI_API_KEY"} {
+		if v := os.Getenv(key); v != "" {
+			pats.literals = append(pats.literals, v)
+		}
+	}
+	return pats
+}

--- a/internal/tools/runner_audit.go
+++ b/internal/tools/runner_audit.go
@@ -1,0 +1,95 @@
+package tools
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// writeAudit emits an NDJSON line capturing tool execution metadata.
+func writeAudit(spec ToolSpec, start time.Time, exitCode, stdoutBytes, stderrBytes int, envKeys []string) {
+	type auditEntry struct {
+		TS          string   `json:"ts"`
+		Tool        string   `json:"tool"`
+		Argv        []string `json:"argv"`
+		CWD         string   `json:"cwd"`
+		Exit        int      `json:"exit"`
+		MS          int64    `json:"ms"`
+		StdoutBytes int      `json:"stdoutBytes"`
+		StderrBytes int      `json:"stderrBytes"`
+		Truncated   bool     `json:"truncated"`
+		EnvKeys     []string `json:"envKeys,omitempty"`
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = ""
+	}
+	entry := auditEntry{
+		TS:          timeNow().UTC().Format(time.RFC3339Nano),
+		Tool:        spec.Name,
+		Argv:        redactSensitiveStrings(append([]string(nil), spec.Command...)),
+		CWD:         redactSensitiveString(cwd),
+		Exit:        exitCode,
+		MS:          time.Since(start).Milliseconds(),
+		StdoutBytes: stdoutBytes,
+		StderrBytes: stderrBytes,
+		Truncated:   false,
+		EnvKeys:     append([]string(nil), envKeys...),
+	}
+	if err := appendAuditLog(entry); err != nil {
+		_ = err
+	}
+}
+
+// appendAuditLog writes an NDJSON audit line to .goagent/audit/YYYYMMDD.log under the repository root.
+// The repository root is determined by walking upward from the current working directory
+// until a directory containing go.mod is found. If no go.mod is found, falls back to CWD.
+func appendAuditLog(entry any) error {
+	b, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	root := moduleRoot()
+	dir := filepath.Join(root, ".goagent", "audit")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	fname := timeNow().UTC().Format("20060102") + ".log"
+	path := filepath.Join(dir, fname)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			_ = err
+		}
+	}()
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+// moduleRoot walks upward from the current working directory to locate the directory
+// containing go.mod. If none is found, it returns the current working directory.
+func moduleRoot() string {
+	cwd, err := os.Getwd()
+	if err != nil || cwd == "" {
+		return "."
+	}
+	dir := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Reached filesystem root; fallback to original cwd
+			return cwd
+		}
+		dir = parent
+	}
+}

--- a/internal/tools/runner_io.go
+++ b/internal/tools/runner_io.go
@@ -1,0 +1,14 @@
+package tools
+
+import (
+	"io"
+)
+
+// safeReadAll reads all bytes from r; on error it returns any bytes read so far (or nil).
+func safeReadAll(r io.Reader) []byte {
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return b
+	}
+	return b
+}

--- a/internal/tools/runner_redact.go
+++ b/internal/tools/runner_redact.go
@@ -1,0 +1,76 @@
+package tools
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+// redactSensitiveStrings applies redactSensitiveString to each element and returns a new slice.
+func redactSensitiveStrings(values []string) []string {
+	out := make([]string, len(values))
+	for i, v := range values {
+		out[i] = redactSensitiveString(v)
+	}
+	return out
+}
+
+// redactSensitiveString masks occurrences of configured sensitive patterns and known secret env values.
+// Patterns are sourced from GOAGENT_REDACT (comma/semicolon-separated substrings or regexes).
+// Additionally, values of well-known secret env vars (OAI_API_KEY, OPENAI_API_KEY) are masked if present.
+func redactSensitiveString(s string) string {
+	if s == "" {
+		return s
+	}
+	// Collect patterns
+	patterns := gatherRedactionPatterns()
+	// Apply regex replacements first
+	for _, rx := range patterns.regexps {
+		s = rx.ReplaceAllString(s, "***REDACTED***")
+	}
+	// Apply literal value masking
+	for _, lit := range patterns.literals {
+		if lit == "" {
+			continue
+		}
+		s = strings.ReplaceAll(s, lit, "***REDACTED***")
+	}
+	return s
+}
+
+type redactionPatterns struct {
+	regexps  []*regexp.Regexp
+	literals []string
+}
+
+// gatherRedactionPatterns builds redaction patterns from environment.
+// GOAGENT_REDACT may contain comma/semicolon separated regex patterns or literals.
+// Known secret env values are added as literal masks.
+func gatherRedactionPatterns() redactionPatterns {
+	var pats redactionPatterns
+	// Configurable patterns
+	cfg := os.Getenv("GOAGENT_REDACT")
+	if cfg != "" {
+		// split by comma or semicolon
+		fields := strings.FieldsFunc(cfg, func(r rune) bool { return r == ',' || r == ';' })
+		for _, f := range fields {
+			f = strings.TrimSpace(f)
+			if f == "" {
+				continue
+			}
+			// Try to compile as regex; if it fails, treat as literal
+			if rx, err := regexp.Compile(f); err == nil {
+				pats.regexps = append(pats.regexps, rx)
+			} else {
+				pats.literals = append(pats.literals, f)
+			}
+		}
+	}
+	// Known secret env values (mask exact substrings)
+	for _, key := range []string{"OAI_API_KEY", "OPENAI_API_KEY"} {
+		if v := os.Getenv(key); v != "" {
+			pats.literals = append(pats.literals, v)
+		}
+	}
+	return pats
+}

--- a/internal/tools/runner_test.go
+++ b/internal/tools/runner_test.go
@@ -1,0 +1,449 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// https://github.com/hyperifyio/goagent/issues/1
+func TestRunToolWithJSON_Timeout(t *testing.T) {
+	dir := t.TempDir()
+
+	// Build a small helper that sleeps longer than timeout
+	helper := filepath.Join(dir, "sleeper.go")
+	if err := os.WriteFile(helper, []byte(`package main
+import ("time"; "os"; "io")
+func main(){_,_ = io.ReadAll(os.Stdin); time.Sleep(2*time.Second)}
+`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	bin := filepath.Join(dir, "sleeper")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	if out, err := exec.Command("go", "build", "-o", bin, helper).CombinedOutput(); err != nil {
+		t.Fatalf("build helper: %v: %s", err, string(out))
+	}
+
+	spec := ToolSpec{Name: "sleep", Command: []string{bin}, TimeoutSec: 1}
+	_, err := RunToolWithJSON(context.Background(), spec, []byte(`{}`), 3*time.Second)
+	if err == nil {
+		t.Fatalf("expected timeout error")
+	}
+	if err.Error() != "tool timed out" {
+		t.Fatalf("expected 'tool timed out', got: %v", err)
+	}
+}
+
+func TestRunToolWithJSON_SuccessEcho(t *testing.T) {
+	dir := t.TempDir()
+	helper := filepath.Join(dir, "echo.go")
+	if err := os.WriteFile(helper, []byte(`package main
+import ("io"; "os"; "fmt")
+func main(){b,_:=io.ReadAll(os.Stdin); fmt.Print(string(b))}
+`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	bin := filepath.Join(dir, "echo")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	if out, err := exec.Command("go", "build", "-o", bin, helper).CombinedOutput(); err != nil {
+		t.Fatalf("build helper: %v: %s", err, string(out))
+	}
+
+	spec := ToolSpec{Name: "echo", Command: []string{bin}, TimeoutSec: 2}
+	out, err := RunToolWithJSON(context.Background(), spec, []byte(`{"a":1}`), 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var js map[string]any
+	if err := json.Unmarshal(out, &js); err != nil {
+		t.Fatalf("bad json echo: %v; out=%s", err, string(out))
+	}
+}
+
+// Ensure deterministic collection order: stderr from a failing tool is surfaced as error
+func TestRunToolWithJSON_NonZeroExit_ReportsStderr(t *testing.T) {
+	dir := t.TempDir()
+	helper := filepath.Join(dir, "fail.go")
+	if err := os.WriteFile(helper, []byte(`package main
+import ("os"; "fmt")
+func main(){fmt.Fprint(os.Stderr, "boom"); os.Exit(3)}
+`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	bin := filepath.Join(dir, "fail")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	if out, err := exec.Command("go", "build", "-o", bin, helper).CombinedOutput(); err != nil {
+		t.Fatalf("build helper: %v: %s", err, string(out))
+	}
+
+	spec := ToolSpec{Name: "fail", Command: []string{bin}, TimeoutSec: 2}
+	_, err := RunToolWithJSON(context.Background(), spec, []byte(`{}`), 5*time.Second)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Error() != "boom" {
+		t.Fatalf("expected stderr content, got: %q", err.Error())
+	}
+}
+
+// https://github.com/hyperifyio/goagent/issues/92
+func TestRunToolWithJSON_AuditLog_WritesLine(t *testing.T) {
+	// Run a quick echo tool and verify a log line is written
+	dir := t.TempDir()
+	helper := filepath.Join(dir, "echo.go")
+	if err := os.WriteFile(helper, []byte(`package main
+import ("io"; "os"; "fmt")
+func main(){b,_:=io.ReadAll(os.Stdin); fmt.Print(string(b))}
+`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	bin := filepath.Join(dir, "echo")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	if out, err := exec.Command("go", "build", "-o", bin, helper).CombinedOutput(); err != nil {
+		t.Fatalf("build helper: %v: %s", err, string(out))
+	}
+
+	// Ensure audit dir at repo root is empty before run
+	root := findRepoRoot(t)
+	if err := os.RemoveAll(filepath.Join(root, ".goagent")); err != nil {
+		t.Logf("cleanup: %v", err)
+	}
+
+	spec := ToolSpec{Name: "echo", Command: []string{bin}, TimeoutSec: 2}
+	out, err := RunToolWithJSON(context.Background(), spec, []byte(`{"ok":true}`), 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("expected output")
+	}
+
+	// Find today's audit log under repo root
+	auditDir := filepath.Join(root, ".goagent", "audit")
+	logFile := waitForAuditFile(t, auditDir, 2*time.Second)
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read audit: %v", err)
+	}
+	// Expect at least one newline-terminated JSON object
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Fatalf("audit log not newline terminated")
+	}
+	// Quick sanity check: file mode should be 0644
+	st, err := os.Stat(logFile)
+	if err == nil {
+		if st.Mode().Type() != fs.ModeType && (st.Mode().Perm()&0o644) == 0 {
+			t.Fatalf("unexpected permissions: %v", st.Mode())
+		}
+	}
+}
+
+// https://github.com/hyperifyio/goagent/issues/92
+func TestRunToolWithJSON_AuditLog_RotationAcrossDateBoundary(t *testing.T) {
+	dir := t.TempDir()
+	helper := filepath.Join(dir, "echo.go")
+	if err := os.WriteFile(helper, []byte(`package main
+import ("io"; "os"; "fmt")
+func main(){b,_:=io.ReadAll(os.Stdin); fmt.Print(string(b))}
+`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	bin := filepath.Join(dir, "echo")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	if out, err := exec.Command("go", "build", "-o", bin, helper).CombinedOutput(); err != nil {
+		t.Fatalf("build helper: %v: %s", err, string(out))
+	}
+
+	// Clean audit dir at repo root
+	root := findRepoRoot(t)
+	if err := os.RemoveAll(filepath.Join(root, ".goagent")); err != nil {
+		t.Logf("cleanup: %v", err)
+	}
+
+	// Freeze time around midnight UTC so successive calls land in different files
+	orig := timeNow
+	defer func() { timeNow = orig }()
+	t1 := time.Date(2025, 1, 2, 23, 59, 59, 0, time.UTC)
+	t2 := t1.Add(2 * time.Second) // 2025-01-03 00:00:01 UTC
+
+	spec := ToolSpec{Name: "echo", Command: []string{bin}, TimeoutSec: 2}
+
+	timeNow = func() time.Time { return t1 }
+	if _, err := RunToolWithJSON(context.Background(), spec, []byte(`{"a":1}`), 5*time.Second); err != nil {
+		t.Fatalf("unexpected error first run: %v", err)
+	}
+
+	timeNow = func() time.Time { return t2 }
+	if _, err := RunToolWithJSON(context.Background(), spec, []byte(`{"b":2}`), 5*time.Second); err != nil {
+		t.Fatalf("unexpected error second run: %v", err)
+	}
+
+	auditDir := filepath.Join(root, ".goagent", "audit")
+	want1 := filepath.Join(auditDir, "20250102.log")
+	want2 := filepath.Join(auditDir, "20250103.log")
+
+	// Allow brief delay for filesystem flush
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err1 := os.Stat(want1); err1 == nil {
+			if _, err2 := os.Stat(want2); err2 == nil {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if _, err := os.Stat(want1); err != nil {
+		t.Fatalf("expected first log file %s: %v", want1, err)
+	}
+	if _, err := os.Stat(want2); err != nil {
+		t.Fatalf("expected second log file %s: %v", want2, err)
+	}
+
+	// Ensure each file has at least one line
+	if b, err := os.ReadFile(want1); err == nil {
+		if len(b) == 0 || b[len(b)-1] != '\n' {
+			t.Fatalf("first audit file empty or not newline terminated")
+		}
+	} else {
+		t.Fatalf("read %s: %v", want1, err)
+	}
+	if b, err := os.ReadFile(want2); err == nil {
+		if len(b) == 0 || b[len(b)-1] != '\n' {
+			t.Fatalf("second audit file empty or not newline terminated")
+		}
+	} else {
+		t.Fatalf("read %s: %v", want2, err)
+	}
+}
+
+// https://github.com/hyperifyio/goagent/issues/92
+func TestRunToolWithJSON_AuditLog_Redaction(t *testing.T) {
+	// Arrange: set env secrets and GOAGENT_REDACT patterns
+	t.Setenv("OAI_API_KEY", "sk-test-1234567890")
+	t.Setenv("GOAGENT_REDACT", "secret,sk-[a-z0-9]+")
+
+	dir := t.TempDir()
+	helper := filepath.Join(dir, "echo.go")
+	if err := os.WriteFile(helper, []byte(`package main
+import ("io"; "os"; "fmt")
+func main(){b,_:=io.ReadAll(os.Stdin); fmt.Print(string(b))}
+`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	bin := filepath.Join(dir, "echo")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	if out, err := exec.Command("go", "build", "-o", bin, helper).CombinedOutput(); err != nil {
+		t.Fatalf("build helper: %v: %s", err, string(out))
+	}
+
+	// Clean audit dir at repo root
+	root := findRepoRoot(t)
+	if err := os.RemoveAll(filepath.Join(root, ".goagent")); err != nil {
+		t.Logf("cleanup: %v", err)
+	}
+
+	// Use argv containing sensitive literals
+	spec := ToolSpec{Name: "echo", Command: []string{bin, "--token=sk-test-1234567890", "--note=contains-secret"}, TimeoutSec: 2}
+	if _, err := RunToolWithJSON(context.Background(), spec, []byte(`{"x":1}`), 5*time.Second); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Locate today's audit file under repo root
+	auditDir := filepath.Join(root, ".goagent", "audit")
+	logFile := waitForAuditFile(t, auditDir, 2*time.Second)
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read audit: %v", err)
+	}
+	// Assert that raw secret substrings are not present
+	if string(data) == "" || len(data) == 0 {
+		t.Fatalf("empty audit")
+	}
+	if bytes := data; bytes != nil {
+		if contains := string(bytes); contains != "" {
+			if string(bytes) != "" && (containsFind(contains, "sk-test-1234567890") || containsFind(contains, "contains-secret")) {
+				t.Fatalf("expected redaction, found sensitive substrings in audit: %s", contains)
+			}
+		}
+	}
+}
+
+// New test encoding the centralized root behavior: logs must be written under
+// the repository root's .goagent/audit, not the package working directory.
+func TestRunToolWithJSON_AuditLog_CentralizedToRepoRoot(t *testing.T) {
+	dir := t.TempDir()
+	helper := filepath.Join(dir, "echo.go")
+	if err := os.WriteFile(helper, []byte(`package main
+import ("io"; "os"; "fmt")
+func main(){b,_:=io.ReadAll(os.Stdin); fmt.Print(string(b))}
+`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	bin := filepath.Join(dir, "echo")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	if out, err := exec.Command("go", "build", "-o", bin, helper).CombinedOutput(); err != nil {
+		t.Fatalf("build helper: %v: %s", err, string(out))
+	}
+
+	root := findRepoRoot(t)
+	// Clean both potential locations to start from a known state
+	if err := os.RemoveAll(filepath.Join(root, ".goagent")); err != nil {
+		t.Logf("cleanup root .goagent: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(".goagent")); err != nil {
+		t.Logf("cleanup cwd .goagent: %v", err)
+	}
+
+	spec := ToolSpec{Name: "echo", Command: []string{bin}, TimeoutSec: 2}
+	if _, err := RunToolWithJSON(context.Background(), spec, []byte(`{"ok":true}`), 5*time.Second); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Expect audit under repo root
+	auditDirRoot := filepath.Join(root, ".goagent", "audit")
+	// This helper will fail if no file appears in the expected root directory
+	_ = waitForAuditFile(t, auditDirRoot, 2*time.Second)
+}
+
+// New test for env passthrough: only allowlisted keys are visible to the child,
+// and audit logs include only key names (not values).
+func TestRunToolWithJSON_EnvPassthrough_KeysOnlyAudit(t *testing.T) {
+	dir := t.TempDir()
+	helper := filepath.Join(dir, "printenv.go")
+	if err := os.WriteFile(helper, []byte(`package main
+import (
+  "encoding/json"; "os"; "fmt"
+)
+func main(){
+  out := map[string]string{
+    "OAI_API_KEY": os.Getenv("OAI_API_KEY"),
+    "OAI_BASE_URL": os.Getenv("OAI_BASE_URL"),
+    "UNSAFE": os.Getenv("UNSAFE"),
+  }
+  b,_ := json.Marshal(out)
+  fmt.Print(string(b))
+}
+`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	bin := filepath.Join(dir, "printenv")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	if out, err := exec.Command("go", "build", "-o", bin, helper).CombinedOutput(); err != nil {
+		t.Fatalf("build helper: %v: %s", err, string(out))
+	}
+
+	// Set env in parent
+	t.Setenv("OAI_API_KEY", "sk-live-should-not-appear-in-audit")
+	t.Setenv("OAI_BASE_URL", "https://example.invalid")
+	t.Setenv("UNSAFE", "DO-NOT-PASS")
+
+	// Clean audit dir at repo root
+	root := findRepoRoot(t)
+	if err := os.RemoveAll(filepath.Join(root, ".goagent")); err != nil {
+		t.Logf("cleanup: %v", err)
+	}
+
+	// Allowlist only OAI_API_KEY and OAI_BASE_URL
+	spec := ToolSpec{Name: "printenv", Command: []string{bin}, TimeoutSec: 2, EnvPassthrough: []string{"OAI_API_KEY", "OAI_BASE_URL"}}
+	out, err := RunToolWithJSON(context.Background(), spec, []byte(`{}`), 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Child should see allowed keys and not see UNSAFE
+	var got map[string]string
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if got["OAI_API_KEY"] == "" || got["OAI_BASE_URL"] == "" {
+		t.Fatalf("allowed envs not visible to child: %v", got)
+	}
+	if got["UNSAFE"] != "" {
+		t.Fatalf("unexpected UNSAFE in child env: %q", got["UNSAFE"])
+	}
+
+	// Audit should include envKeys but never the secret values
+	auditDir := filepath.Join(root, ".goagent", "audit")
+	logFile := waitForAuditFile(t, auditDir, 2*time.Second)
+	data, errRead := os.ReadFile(logFile)
+	if errRead != nil {
+		t.Fatalf("read audit: %v", errRead)
+	}
+	s := string(data)
+	// Must mention the keys
+	if !strings.Contains(s, "\"envKeys\"") || !(strings.Contains(s, "OAI_API_KEY") && strings.Contains(s, "OAI_BASE_URL")) {
+		t.Fatalf("audit missing envKeys or keys: %s", s)
+	}
+	// Must not contain the actual secret value
+	if strings.Contains(s, "sk-live-should-not-appear-in-audit") || strings.Contains(s, fmt.Sprintf("%q", "sk-live-should-not-appear-in-audit")) {
+		t.Fatalf("secret value leaked into audit: %s", s)
+	}
+}
+
+// findRepoRoot walks upward from CWD to locate the directory containing go.mod.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	start, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := start
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("go.mod not found from %s upward", start)
+		}
+		dir = parent
+	}
+}
+
+// waitForAuditFile polls the audit directory until a file appears or timeout elapses.
+func waitForAuditFile(t *testing.T, auditDir string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		entries, err := os.ReadDir(auditDir)
+		if err == nil {
+			for _, e := range entries {
+				if !e.IsDir() {
+					return filepath.Join(auditDir, e.Name())
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("audit log not created in %s", auditDir)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// containsFind is a tiny helper to avoid importing strings in this test's top-level import list diff
+func containsFind(s, sub string) bool { return strings.Contains(s, sub) }

--- a/internal/tools/spec.go
+++ b/internal/tools/spec.go
@@ -1,0 +1,11 @@
+package tools
+
+// ToolSpec defines how to execute a tool process.
+// Only fields required by the runner and tests are included here.
+// Additional fields may be added in future as needed by the tool ecosystem.
+type ToolSpec struct {
+	Name           string   // human-readable tool name for audit
+	Command        []string // argv vector: program and its arguments
+	TimeoutSec     int      // per-invocation timeout in seconds; 0 uses default
+	EnvPassthrough []string // environment variable keys to pass through to the child
+}


### PR DESCRIPTION
## Summary
Adds secure tool runner (argv-only) with:
- Per-tool timeouts and deterministic error mapping
- Minimal env passthrough (allowlist) and audit logging
- Centralized NDJSON audit under repo root

## Scope
Only - \ - \

## Risks
- Low; isolated to runner package. No integration wiring here.

## Test plan
- Unit tests in \ compile and pass on a branch with repo go.mod present. CI will run the package tests.

Refs: FEATURE_CHECKLIST.md (#07)