### PR TITLE
Tool: get_time example + manifest + Makefile wiring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,368 @@
+SHELL := /bin/bash
+
+GO ?= go
+CGO_ENABLED ?= 0
+GOOS ?= $(shell $(GO) env GOOS)
+GOARCH ?= $(shell $(GO) env GOARCH)
+
+# Reproducible builds: trim local paths, strip symbols, disable VCS stamping,
+# and clear build id for identical binaries across clean builds
+BUILD_FLAGS ?= -trimpath -buildvcs=false
+LD_FLAGS ?= -s -w -buildid=
+
+# Pin golangci-lint to a version compatible with current Go
+GOLANGCI_LINT_VERSION ?= v1.62.0
+
+# Deterministic local bin directory for tool installs
+GOBIN ?= $(CURDIR)/bin
+
+# Executable suffix for Windows builds
+EXE :=
+ifeq ($(GOOS),windows)
+EXE := .exe
+endif
+
+# Canonical list of tool binaries built under tools/bin in stable order
+TOOLS := \
+  get_time \
+  exec \
+  fs_read_file \
+  fs_write_file \
+  fs_append_file \
+  fs_rm \
+  fs_move \
+  fs_search \
+  fs_mkdirp \
+  fs_apply_patch \
+  fs_read_lines \
+  fs_edit_range \
+  fs_listdir \
+  fs_stat \
+  img_create \
+  http_fetch \
+  searxng_search \
+  robots_check \
+  readability_extract \
+  metadata_extract \
+  pdf_extract \
+  rss_fetch \
+  wayback_lookup \
+  wiki_query \
+  openalex_search \
+  crossref_search \
+  github_search \
+  citation_pack
+
+.PHONY: tidy build build-tools build-tool test clean clean-logs clean-all test-clean-logs lint lint-precheck fmt fmtcheck verify-manifest-paths bootstrap ensure-rg check-go-version install-golangci
+
+tidy:
+	$(GO) mod tidy
+
+build:
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(BUILD_FLAGS) -ldflags '$(LD_FLAGS)' -o bin/agentcli ./cmd/agentcli
+
+build-tools:
+	mkdir -p tools/bin
+	@set -e; \
+	for t in $(TOOLS); do \
+	  echo "Building $$t"; \
+	  GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(BUILD_FLAGS) -ldflags '$(LD_FLAGS)' -o tools/bin/$$t$(EXE) ./tools/cmd/$$t; \
+	done
+
+# Build a single tool binary into tools/bin/$(NAME)
+# Usage: make build-tool NAME=fs_read_file
+build-tool:
+	@set -eo pipefail; \
+	if [ -z "$(NAME)" ]; then \
+	  echo "Usage: make build-tool NAME=<name>"; \
+	  echo "Available tools: $(TOOLS)"; \
+	  exit 2; \
+	fi; \
+	case " $(TOOLS) " in \
+	  *" $(NAME) "*) ;; \
+	  *) echo "Unknown tool: $(NAME). Allowed: $(TOOLS)"; exit 2;; \
+	esac; \
+	mkdir -p tools/bin; \
+	echo "Building $(NAME)"; \
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(BUILD_FLAGS) -ldflags '$(LD_FLAGS)' -o tools/bin/$(NAME)$(EXE) ./tools/cmd/$(NAME)
+
+test:
+	$(GO) test ./...
+
+# Smoke test for image flow: run CLI with a deterministic prompt and require non-empty output
+.PHONY: smoke-image
+smoke-image: build build-tools
+	@set -euo pipefail; \
+	if [ ! -x ./bin/agentcli ]; then echo "smoke-image: ./bin/agentcli missing"; exit 2; fi; \
+	if [ ! -x ./tools/bin/img_create$(EXE) ]; then echo "smoke-image: ./tools/bin/img_create$(EXE) missing (run make build-tools)"; exit 2; fi; \
+	# Require API base and key for a real run; allow user to point to a mock
+	: "$${OAI_IMAGE_BASE_URL:=${OAI_BASE_URL:-}}"; \
+	if [ -z "$$OAI_IMAGE_BASE_URL" ]; then echo "smoke-image: set OAI_IMAGE_BASE_URL or OAI_BASE_URL"; exit 2; fi; \
+	: "$${OAI_API_KEY:-}"; \
+	if [ -z "$$OAI_API_KEY" ]; then echo "smoke-image: set OAI_API_KEY"; exit 2; fi; \
+	TMP=$$(mktemp -d 2>/dev/null || mktemp -d -t simg); \
+	TOOLS_JSON="$$TMP/tools.json"; \
+	jq -n '{tools:[{name:"img_create",description:"Generate images",schema:{type:"object",additionalProperties:false,required:["prompt"],properties:{prompt:{type:"string"},n:{type:"integer",minimum:1,maximum:4,default:1},size:{type:"string",pattern:"^\\d{3,4}x\\d{3,4}$",default:"1024x1024"},model:{type:"string",default:"gpt-image-1"},return_b64:{type:"boolean",default:false},save:{type:"object",additionalProperties:false,required:["dir"],properties:{dir:{type:"string"},basename:{type:"string",default:"img"},ext:{type:"string",enum:["png"],default:"png"}}}}},command:["./tools/bin/img_create"],timeoutSec:120,envPassthrough:["OAI_API_KEY","OAI_BASE_URL","OAI_IMAGE_BASE_URL","OAI_HTTP_TIMEOUT"]}]}' > "$$TOOLS_JSON"; \
+	OUT=$$(./bin/agentcli -tools "$$TOOLS_JSON" -prompt "Use img_create to save under out/" -model gpt-5 -max-steps 3 -http-timeout 10s -tool-timeout 20s -debug 2>/dev/null || true); \
+	if [ -z "$$OUT" ]; then echo "smoke-image: empty CLI output"; exit 1; fi; \
+	echo "smoke-image: OK: $$OUT"; \
+	rm -rf "$$TMP"
+
+clean:
+	# Remove agent binary and each tool binary deterministically
+	rm -f $(addprefix tools/bin/,$(addsuffix $(EXE),$(TOOLS)))
+	rm -rf tools/bin
+	rm -rf bin
+	# Remove common test/build artifacts
+	rm -f bin/coverage.out coverage.out
+	rm -rf reports
+	# Remove local audit/log artifacts created during tests
+	rm -rf .goagent
+	# Intentionally preserve logs/ here; see clean-logs for guarded deletion
+	# rm -rf logs
+
+# Guarded logs cleanup: only delete when STATE equals DOWN
+# Usage:
+#   make clean-logs                 # operates on ./logs (default)
+#   make clean-logs LOGS_DIR=path   # operate on a specific logs dir (used by tests)
+LOGS_DIR ?= logs
+clean-logs:
+	@set -euo pipefail; \
+	DIR="$(LOGS_DIR)"; \
+	if [ ! -d "$$DIR" ]; then \
+	  echo "clean-logs: $$DIR not present; skipping"; \
+	  exit 0; \
+	fi; \
+	STATE=$$(tr -d ' \t\r\n' < "$$DIR/STATE" 2>/dev/null || true); \
+	if [ "$$STATE" = "DOWN" ]; then \
+	  rm -rf "$$DIR"; \
+	  echo "clean-logs: removed $$DIR"; \
+	else \
+	  echo "clean-logs: skipped ($$DIR/STATE='$$STATE')"; \
+	fi
+
+# Aggregate clean: normal clean then guarded logs cleanup
+clean-all:
+	@$(MAKE) clean
+	@$(MAKE) clean-logs
+
+# Fail early if the active Go toolchain (major.minor) differs from go.mod
+# Usage: make check-go-version
+check-go-version:
+	@set -euo pipefail; \
+    		# Extract version declared in go.mod and normalize to major.minor (ignore patch)
+    		# Prefer `go mod edit -json` for robust parsing across environments
+    		MOD_GO=$$(go mod edit -json | sed -nE 's/.*"Go"[[:space:]]*:[[:space:]]*"([0-9]+\.[0-9]+).*/\1/p' | head -n1 | tr -d ' \t\r\n'); \
+        if [ -z "$$MOD_GO" ]; then echo "check-go-version: unable to parse major.minor from go.mod"; exit 2; fi; \
+        # Extract system Go major.minor
+		SYS_GO=$$(go env GOVERSION | sed -E 's/^go([0-9]+\.[0-9]+).*/\1/' | tr -d ' \t\r\n'); \
+        if [ -z "$$SYS_GO" ]; then echo "check-go-version: unable to parse 'go version' output"; exit 2; fi; \
+        if [ "$$SYS_GO" != "$$MOD_GO" ]; then \
+          echo "Go toolchain mismatch: system $$SYS_GO != go.mod $$MOD_GO"; \
+          echo "Hint: install Go $$MOD_GO (see https://go.dev/dl) or use a version manager, then re-run 'make check-go-version'."; \
+          exit 2; \
+        fi; \
+        echo "check-go-version: OK (system $$SYS_GO matches go.mod $$MOD_GO)"
+
+# Deterministic tests for clean-logs behavior across cases
+# - DOWN => directory removed
+# - non-DOWN => directory preserved
+# - missing STATE => directory preserved
+test-clean-logs:
+	@set -euo pipefail; \
+	TMP=$$(mktemp -d 2>/dev/null || mktemp -d -t clogs); \
+	LD="$$TMP/logs"; \
+	: # Case A: allowed removal when STATE=DOWN; \
+	mkdir -p "$$LD"; \
+	echo DOWN > "$$LD/STATE"; \
+	touch "$$LD/file"; \
+	$(MAKE) -s clean-logs LOGS_DIR="$$LD"; \
+	if [ -d "$$LD" ]; then echo "test-clean-logs: expected removal when STATE=DOWN"; rm -rf "$$TMP"; exit 1; fi; \
+	: # Case B: blocked when STATE!=DOWN; \
+	mkdir -p "$$LD"; \
+	echo UP > "$$LD/STATE"; \
+	$(MAKE) -s clean-logs LOGS_DIR="$$LD"; \
+	if [ ! -d "$$LD" ]; then echo "test-clean-logs: unexpected removal when STATE!=DOWN"; rm -rf "$$TMP"; exit 1; fi; \
+	: # Case C: blocked when STATE missing; \
+	rm -rf "$$LD"; \
+	mkdir -p "$$LD"; \
+	rm -f "$$LD/STATE"; \
+	$(MAKE) -s clean-logs LOGS_DIR="$$LD"; \
+	if [ ! -d "$$LD" ]; then echo "test-clean-logs: unexpected removal when STATE missing"; rm -rf "$$TMP"; exit 1; fi; \
+	# Cleanup; \
+	rm -rf "$$TMP"; \
+	echo "test-clean-logs: OK"
+
+lint:
+	@$(MAKE) check-go-version
+	@set -euo pipefail; \
+		LINTBIN="$(GOBIN)/golangci-lint$(EXE)"; \
+    # Fail fast if an existing linter is too old relative to MIN \
+	$(MAKE) -s lint-precheck; \
+	NEED_INSTALL=0; \
+	if [ ! -x "$$LINTBIN" ]; then \
+	  NEED_INSTALL=1; \
+	else \
+	  CUR_VER="$$($$LINTBIN version | sed -nE 's/.*version ([v0-9\.]+).*/\1/p')"; \
+	  if [ "$$CUR_VER" != "$(GOLANGCI_LINT_VERSION)" ]; then NEED_INSTALL=1; fi; \
+	fi; \
+	if [ "$$NEED_INSTALL" = "1" ]; then \
+	  echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION) into $(GOBIN)..."; \
+	  $(MAKE) install-golangci; \
+	fi; \
+	"$$LINTBIN" version; \
+	"$$LINTBIN" run --timeout=5m; \
+	$(GO) vet ./...; \
+	$(MAKE) fmtcheck; \
+	$(MAKE) ensure-rg; \
+	PATH="$(CURDIR)/bin:$$PATH" $(MAKE) check-tools-paths; \
+	PATH="$(CURDIR)/bin:$$PATH" $(MAKE) verify-manifest-paths
+
+# Verify ordering inside the lint target via make dry-run
+# Ensures the first non-commented command is the sub-make invocation of check-go-version
+# and that a golangci-lint version invocation appears later.
+.PHONY: test-lint-order
+test-lint-order:
+	@set -euo pipefail; \
+	OUT="$$(make -n lint 2>/dev/null)"; \
+	FIRST_LINE="$$(printf '%s\n' "$$OUT" | sed -n '1p')"; \
+	if [ "$$FIRST_LINE" != "make check-go-version" ]; then \
+	  printf '%s\n' "test-lint-order: expected first line 'make check-go-version' but got: $$FIRST_LINE"; \
+	  exit 1; \
+	fi; \
+	if ! printf '%s\n' "$$OUT" | awk '/golangci-lint/{found=1} END{exit found?0:1}'; then \
+	  printf '%s\n' "test-lint-order: expected to find a golangci-lint invocation in dry-run output"; \
+	  exit 1; \
+	fi; \
+	printf '%s\n' "test-lint-order: OK"
+
+# Fail fast when golangci-lint is older than the minimum supported version
+# Usage: make lint-precheck
+lint-precheck:
+	@set -euo pipefail; \
+	LINTBIN="$(GOBIN)/golangci-lint$(EXE)"; \
+	MIN="v1.60.0"; \
+	if [ ! -x "$$LINTBIN" ]; then \
+	  # Not installed yet; installation in the lint target will handle it \
+	  echo "lint-precheck: $$LINTBIN not found; will install $(GOLANGCI_LINT_VERSION)"; \
+	  exit 0; \
+	fi; \
+	GCL="$$($$LINTBIN version | sed -nE 's/.*version ([v0-9\.]+).*/\1/p')"; \
+	if [ -z "$$GCL" ]; then \
+	  echo "lint-precheck: unable to parse golangci-lint version from '$$($$LINTBIN version | head -n1)'"; \
+	  exit 2; \
+	fi; \
+	MAX_VER="$$(printf '%s\n%s\n' "$$GCL" "$$MIN" | sort -V | tail -n1)"; \
+	if [ "$$MAX_VER" != "$$GCL" ]; then \
+	  echo "golangci-lint $$GCL < $$MIN with Go $$(go version) — update GOLANGCI_LINT_VERSION"; \
+	  exit 2; \
+	fi; \
+	echo "lint-precheck: OK (golangci-lint $$GCL >= $$MIN)"
+
+## Pin ripgrep for optional local, non-root install when missing
+RG_VERSION ?= 14.1.0
+
+# Ensure ripgrep (rg) is available; if not, download a static build into ./bin/rg
+ensure-rg:
+	@set -euo pipefail; \
+	if command -v rg >/dev/null 2>&1; then \
+	  exit 0; \
+	fi; \
+	echo "ripgrep (rg) not found; installing to ./bin/rg (version $(RG_VERSION))"; \
+	mkdir -p bin; \
+	OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
+	ARCH=$$(uname -m); \
+	case "$$OS" in \
+	  linux) TOS=unknown-linux-musl;; \
+	  darwin) TOS=apple-darwin;; \
+	  *) echo "Unsupported OS for auto-install: $$OS"; exit 1;; \
+	esac; \
+	case "$$ARCH" in \
+	  x86_64|amd64) TARCH=x86_64;; \
+	  arm64|aarch64) TARCH=aarch64;; \
+	  *) echo "Unsupported arch for auto-install: $$ARCH"; exit 1;; \
+	esac; \
+	URL="https://github.com/BurntSushi/ripgrep/releases/download/$(RG_VERSION)/ripgrep-$(RG_VERSION)-$$TARCH-$$TOS.tar.gz"; \
+	TMP=$$(mktemp -d 2>/dev/null || mktemp -d -t rgdl); \
+	echo "Downloading $$URL"; \
+	if ! curl -fsSL "$$URL" | tar -xz -C "$$TMP"; then \
+	  echo "Failed to download/extract ripgrep archive"; rm -rf "$$TMP"; exit 1; \
+	fi; \
+	SRC=$$(find "$$TMP" -type f -name rg -perm -u+x | head -n1); \
+	if [ -z "$$SRC" ]; then \
+	  echo "rg binary not found in archive"; rm -rf "$$TMP"; exit 1; \
+	fi; \
+	mv "$$SRC" bin/rg; \
+	chmod +x bin/rg; \
+	rm -rf "$$TMP"; \
+	bin/rg --version | head -n1; \
+	echo "ripgrep installed at ./bin/rg"
+
+# Install pinned golangci-lint into ./bin using the local Go toolchain
+install-golangci:
+	@set -euo pipefail; \
+	mkdir -p "$(GOBIN)"; \
+	GOBIN="$(GOBIN)" GO111MODULE=on $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
+	"$(GOBIN)/golangci-lint$(EXE)" version
+
+# Auto-format Go sources in-place using gofmt -s
+fmt:
+	@gofmt -s -w .
+
+# Verify tools.json commands use canonical ./tools/bin prefix for relative paths
+# Fails if any command[0] is relative and does not start with ./tools/bin/
+# Absolute paths are allowed for test fixtures. Requires ripgrep (rg).
+verify-manifest-paths:
+	@set -euo pipefail; \
+	if ! command -v rg >/dev/null 2>&1; then \
+		echo "ripgrep (rg) is required. Please install ripgrep."; \
+		exit 1; \
+	fi; \
+	if [ ! -f tools.json ]; then \
+		echo "tools.json not found at repo root"; \
+		exit 1; \
+	fi; \
+	if rg -n -P --no-heading '"command"\s*:\s*\[\s*"(?!\./tools/bin/)(\./[^"]+)"' tools.json; then \
+		echo "Invalid relative command[0] in tools.json. Use ./tools/bin/NAME or an absolute path."; \
+		exit 1; \
+	fi; \
+	echo "verify-manifest-paths: OK"
+
+fmtcheck:
+	@echo "Checking gofmt..."; \
+	files=$$(gofmt -s -l .); \
+	if [ -n "$$files" ]; then \
+		echo "Files need gofmt -s:"; echo "$$files"; exit 1; \
+	fi
+
+# Guard against legacy tool path usage outside canonical layout
+# - Fails if any "./tools/(get_time|fs_*|exec)" invocation remains outside allowed paths
+# - Also fails on single-file references like "./tools/<name>.go".
+#   Allowed: "go build -o tools/bin/<name> ./tools/cmd/<name>". Forbidden: building directly from "./tools/<name>" outside `tools/cmd/**` and `tools/bin/**` (excluding FEATURE_CHECKLIST.md).
+# Requires ripgrep (`rg`).
+check-tools-paths:
+	@set -euo pipefail; \
+	if ! command -v rg >/dev/null 2>&1; then \
+		echo "ripgrep (rg) is required. Please install ripgrep."; \
+		exit 1; \
+	fi; \
+	# Legacy invocations of tools outside canonical layout
+	if rg -n --no-heading --hidden \
+		-g '!tools/cmd/**' -g '!tools/bin/**' -g '!FEATURE_CHECKLIST.md' -g '!.git/**' \
+		-e '\./tools/(get_time|fs_[a-z_]+|exec)\b' .; then \
+		echo "Forbidden legacy tool path references found. Use ./tools/bin/NAME or sources under tools/cmd/NAME."; \
+		exit 1; \
+	fi; \
+	# Single-file source builds or direct `go build/run` against ./tools/<name> are forbidden
+	# Use PCRE2 to exclude allowed ./tools/cmd/* and ./tools/bin/* via negative lookahead
+	if rg -n -P --no-heading --hidden \
+		-g '!tools/cmd/**' -g '!tools/bin/**' -g '!FEATURE_CHECKLIST.md' -g '!.git/**' \
+		-e '(\./tools/[a-z_]+\.go|go\s+(build|run)\s+.*\s\./tools/(?!cmd/|bin/)[a-z_]+)\b' .; then \
+		echo "Direct tool source builds or single-file references found. Build from tools/cmd/NAME -> tools/bin/NAME."; \
+		exit 1; \
+	fi; \
+	echo "check-tools-paths: OK"
+
+# Initialize and update git submodules (e.g., scripts and rules)
+bootstrap:
+	@git submodule update --init --recursive

--- a/README.md
+++ b/README.md
@@ -1,1 +1,702 @@
-# goagent
+# goagent — Minimal, safe, non‑interactive agent CLI
+
+[![CI (lint+test+build)](https://github.com/hyperifyio/goagent/actions/workflows/ci.yml/badge.svg)](https://github.com/hyperifyio/goagent/actions/workflows/ci.yml)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/hyperifyio/goagent)](https://github.com/hyperifyio/goagent/blob/main/go.mod)
+[![Go Reference](https://pkg.go.dev/badge/github.com/hyperifyio/goagent.svg)](https://pkg.go.dev/github.com/hyperifyio/goagent)
+[![Release](https://img.shields.io/github/v/release/hyperifyio/goagent?sort=semver)](https://github.com/hyperifyio/goagent/releases)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+goagent is a compact, vendor‑agnostic command‑line tool for running non‑interactive, tool‑using agents against any OpenAI‑compatible Chat Completions API. It executes a small, auditable allowlist of local tools (argv only; no shell), streams JSON in/out, and prints a concise final answer.
+
+- Why use it: deterministic, portable, and safe by default. Works with hosted providers and with local endpoints like `http://localhost:1234/v1`.
+- Who it’s for: engineers who want a minimal agent runner with clear guarantees and zero vendor lock‑in.
+- What makes it different: strict "argv‑only" tool execution, explicit allowlists, and a pragmatic default LLM policy for predictable behavior across providers.
+
+## Table of contents
+- [At a glance](#at-a-glance)
+- [Features](#features)
+- [Installation](#installation)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+  - [Common flags](#common-flags)
+  - [Image generation flags](#image-generation-flags)
+  - [Why you usually don’t need to change knobs](#why-you-usually-dont-need-to-change-knobs)
+  - [Capabilities](#capabilities)
+- [Configuration](#configuration)
+  - [Inheritance and precedence](#inheritance-and-precedence)
+- [Examples](#examples)
+  - [Zero-config with GPT-5](#zero-config-with-gpt-5)
+  - [Tool calls transcript](#tool-calls-transcript)
+  - [Worked example: tool calls and transcript](#worked-example-tool-calls-and-transcript)
+  - [View refined messages (pre-stage and final)](#view-refined-messages-pre-stage-and-final)
+  - [Exec tool](#exec-tool)
+  - [Filesystem tools](#filesystem-tools)
+  - [Image generation tool (img_create)](#image-generation-tool-img_create)
+  - [fs_search](#fs_search)
+- [Security](#security)
+- [Troubleshooting](#troubleshooting)
+- [Tests](#tests)
+ - [Documentation](#documentation)
+- [Diagrams](#diagrams)
+- [Contributing](#contributing)
+- [Development tooling](#tooling)
+- [Support](#support)
+- [Roadmap](#roadmap)
+- [Project status](#project-status)
+- [License and credits](#license-and-credits)
+- [Changelog](#changelog)
+- [More examples](#more-examples)
+- [CI quality gates](docs/operations/ci-quality-gates.md)
+ - [State persistence (-state-dir)](#state-persistence--state-dir)
+
+
+## At a glance
+- Minimal, portable, vendor‑agnostic: works with any OpenAI‑compatible endpoint
+- Deterministic and auditable: argv‑only tool execution, JSON stdin/stdout, strict timeouts
+- Safe by default: explicit allowlist of tools; no shell evaluation
+- Batteries included: a small toolbelt for filesystem, process, network, and image tasks
+
+## Features
+- OpenAI‑compatible `POST /v1/chat/completions` via `net/http` (no SDK)
+- **Explicit tools allowlist**: `tools.json` with JSON Schema parameters (see [Tools manifest reference](docs/reference/tools-manifest.md))
+- **Deterministic execution**: argv‑only tools, JSON stdin/stdout, per‑call timeouts
+- **Predictable error surface**: tool errors mapped as structured JSON
+- **Observability & hygiene**: audit logging with redaction; transcript size controls
+
+## Installation
+
+### Requirements
+- Go 1.24+ on Linux, macOS, or Windows
+- Network access to an OpenAI‑compatible API
+- For development and examples: `ripgrep` (rg), `jq`, and `golangci-lint`
+
+### Install options
+1) Download a binary: see [Releases](https://github.com/hyperifyio/goagent/releases)
+
+2) With Go (adds `agentcli` to your `GOBIN`):
+```bash
+go install github.com/hyperifyio/goagent/cmd/agentcli@latest
+```
+
+3) Build from source:
+```bash
+git clone https://github.com/hyperifyio/goagent
+cd goagent
+make bootstrap tidy build build-tools
+```
+
+Verify installation:
+```bash
+./bin/agentcli --version
+```
+
+Developer prerequisites (examples):
+```bash
+# ripgrep
+# - Ubuntu/Debian
+sudo apt-get update && sudo apt-get install -y ripgrep
+# - macOS (Homebrew)
+brew install ripgrep
+# - Windows (Chocolatey)
+choco install ripgrep -y
+
+# golangci-lint (pinned; installs into ./bin via Makefile)
+make install-golangci
+./bin/golangci-lint version
+
+# jq (used by examples and runbooks)
+# - Ubuntu/Debian
+sudo apt-get install -y jq
+# - macOS (Homebrew)
+brew install jq
+# - Windows (Chocolatey)
+choco install jq -y
+
+# make (Windows, for running Makefile targets used in docs)
+# - Windows (Chocolatey)
+choco install make -y
+```
+
+## Configuration
+Configuration precedence is: **flags > environment > built‑in defaults**.
+
+Environment variables:
+- `OAI_BASE_URL` — API base (default `https://api.openai.com/v1`). Helper scripts will also read `LLM_BASE_URL` if present.
+- `OAI_MODEL` — model ID (default `oss-gpt-20b`). Helper scripts will also read `LLM_MODEL` if present.
+- `OAI_API_KEY` — API key when required. The CLI also accepts `OPENAI_API_KEY` for compatibility.
+- `OAI_HTTP_TIMEOUT` — HTTP timeout for chat requests (e.g., `90s`). Mirrors `-http-timeout`.
+  `OAI_PREP_HTTP_TIMEOUT` — HTTP timeout for pre-stage; overrides inheritance from `-http-timeout`.
+
+### Inheritance and precedence
+
+The CLI resolves values independently for chat (main), pre-stage, and image flows, with inheritance when explicit values are not provided.
+
+Endpoints and API keys:
+
+| Setting | Resolution order |
+|---|---|
+| Chat base URL | `-base-url` → `OAI_BASE_URL` → default `https://api.openai.com/v1` |
+| Pre-stage base URL | `-prep-base-url` → `OAI_PREP_BASE_URL` → inherit Chat base URL |
+| Image base URL | `-image-base-url` → `OAI_IMAGE_BASE_URL` → inherit Chat base URL |
+| Chat API key | `-api-key` → `OAI_API_KEY` → `OPENAI_API_KEY` |
+| Pre-stage API key | `-prep-api-key` → `OAI_PREP_API_KEY` → inherit Chat API key |
+| Image API key | `-image-api-key` → `OAI_IMAGE_API_KEY` → inherit Chat API key |
+
+Models and sampling:
+
+| Setting | Resolution order |
+|---|---|
+| Chat model | `-model` → `OAI_MODEL` → default `oss-gpt-20b` |
+| Pre-stage model | `-prep-model` → `OAI_PREP_MODEL` → inherit Chat model |
+| Image model | `-image-model` → `OAI_IMAGE_MODEL` → default `gpt-image-1` |
+| Chat temperature vs top-p | One‑knob rule: if `-top-p` is set, omit `temperature`; otherwise send `-temp` (default 1.0) when supported |
+| Pre-stage temperature vs top-p | One‑knob rule applies independently with `-prep-temp`/`-prep-top-p` |
+
+HTTP controls:
+
+| Setting | Resolution order |
+|---|---|
+| Chat HTTP timeout | `-http-timeout` → `OAI_HTTP_TIMEOUT` → fallback to `-timeout` if set |
+| Pre-stage HTTP timeout | `-prep-http-timeout` → `OAI_PREP_HTTP_TIMEOUT` → inherit Chat HTTP timeout |
+| Image HTTP timeout | `-image-http-timeout` → `OAI_IMAGE_HTTP_TIMEOUT` → inherit Chat HTTP timeout |
+| Chat HTTP retries | `-http-retries` → `OAI_HTTP_RETRIES` → default (e.g., 2) |
+| Pre-stage HTTP retries | `-prep-http-retries` → `OAI_PREP_HTTP_RETRIES` → inherit Chat HTTP retries |
+| Image HTTP retries | `-image-http-retries` → `OAI_IMAGE_HTTP_RETRIES` → inherit Chat HTTP retries |
+| Chat HTTP retry backoff | `-http-retry-backoff` → `OAI_HTTP_RETRY_BACKOFF` → default |
+| Pre-stage HTTP retry backoff | `-prep-http-retry-backoff` → `OAI_PREP_HTTP_RETRY_BACKOFF` → inherit Chat backoff |
+| Image HTTP retry backoff | `-image-http-retry-backoff` → `OAI_IMAGE_HTTP_RETRY_BACKOFF` → inherit Chat backoff |
+
+## Quick start
+Install the CLI and point it to a reachable OpenAI‑compatible API (local or hosted):
+```bash
+export OAI_BASE_URL=http://localhost:1234/v1
+export OAI_MODEL=oss-gpt-20b
+make build build-tools # skip if installed via go install / release binary
+```
+
+Create a minimal `tools.json` next to the binary (Unix/macOS):
+```json
+{
+  "tools": [
+    {
+      "name": "get_time",
+      "description": "Return current time for an IANA timezone (default UTC). Accepts 'timezone' (canonical) and alias 'tz'.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "timezone": {"type": "string", "description": "e.g. Europe/Helsinki"},
+          "tz": {"type": "string", "description": "Alias for timezone (deprecated)"}
+        },
+        "required": ["timezone"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/get_time"],
+      "timeoutSec": 5
+    }
+  ]
+}
+```
+
+On Windows, use a `.exe` suffix for tool binaries:
+```json
+{
+  "tools": [
+    {
+      "name": "get_time",
+      "schema": {"type":"object","properties":{"timezone":{"type":"string"}},"required":["timezone"],"additionalProperties":false},
+      "command": ["./tools/bin/get_time.exe"],
+      "timeoutSec": 5
+    }
+  ]
+}
+```
+
+Run the agent:
+```bash
+./bin/agentcli \
+  -prompt "What's the local time in Helsinki? If tools are available, call get_time." \
+  -tools ./tools.json \
+  -debug
+```
+
+Expected behavior: the model may call `get_time`; the CLI executes `./tools/bin/get_time` (or `get_time.exe` on Windows) with JSON on stdin, appends the result as a `tool` message, calls the API again, then prints a concise final answer.
+
+Tip: run `./bin/agentcli -h` for the complete help output.
+
+## Usage
+Flags are order‑insensitive. You can place `-prompt` and other flags in any order; precedence remains flag > environment > default.
+### Common flags
+```text
+-prompt string         User prompt (required)
+-tools string          Path to tools.json (optional)
+-system string         System prompt (default: helpful and precise)
+-base-url string       OpenAI‑compatible base URL (env OAI_BASE_URL; scripts accept LLM_BASE_URL fallback)
+-api-key string        API key if required (env OAI_API_KEY; falls back to OPENAI_API_KEY)
+-model string          Model ID (env OAI_MODEL; scripts accept LLM_MODEL fallback)
+-max-steps int         Maximum reasoning/tool steps (default 8)
+                       A hard ceiling of 15 is enforced; exceeding the cap
+                       terminates with: "needs human review".
+-http-timeout duration HTTP timeout for chat completions (env OAI_HTTP_TIMEOUT; default falls back to -timeout)
+-prep-http-timeout duration HTTP timeout for pre-stage (env OAI_PREP_HTTP_TIMEOUT; default falls back to -http-timeout)
+-prep-model string      Pre-stage model ID (env OAI_PREP_MODEL; inherits -model if unset)
+-prep-base-url string   Pre-stage base URL (env OAI_PREP_BASE_URL; inherits -base-url if unset)
+-prep-api-key string    Pre-stage API key (env OAI_PREP_API_KEY; falls back to OAI_API_KEY/OPENAI_API_KEY; inherits -api-key if unset)
+-prep-http-retries int  Pre-stage HTTP retries (env OAI_PREP_HTTP_RETRIES; inherits -http-retries if unset)
+-prep-http-retry-backoff duration Pre-stage HTTP retry backoff (env OAI_PREP_HTTP_RETRY_BACKOFF; inherits -http-retry-backoff if unset)
+-prep-dry-run           Run pre-stage only, print refined Harmony messages to stdout, and exit 0
+-print-messages         Pretty-print the final merged message array to stderr before the main call
+-http-retries int      Number of retries for transient HTTP failures (timeouts, 429, 5xx). Uses jittered exponential backoff. (default 2)
+-http-retry-backoff duration Base backoff between HTTP retry attempts (exponential with jitter). (default 300ms)
+-tool-timeout duration Per-tool timeout (default falls back to -timeout)
+-timeout duration      [DEPRECATED] Global timeout; prefer -http-timeout and -tool-timeout
+-temp float            Sampling temperature (default 1.0)
+-top-p float           Nucleus sampling probability mass (conflicts with -temp; omits temperature when set)
+-prep-top-p float      Nucleus sampling probability mass for pre-stage (conflicts with -temp; omits temperature when set)
+-prep-profile string   Pre-stage prompt profile (deterministic|general|creative|reasoning); sets temperature when supported (conflicts with -prep-top-p)
+-prep-enabled          Enable pre-stage (default true). When false, skip pre-stage and proceed directly to main call.
+-debug                 Dump request/response JSON to stderr
+-verbose               Also print non-final assistant channels (critic/confidence) to stderr
+-channel-route name=stdout|stderr|omit
+                       Override default channel routing (final→stdout, critic/confidence→stderr); repeatable
+-quiet                 Suppress non-final output; print only final text to stdout
+-capabilities          Print enabled tools and exit
+-print-config          Print resolved config and exit
+-dry-run               Print intended state actions (restore/refine/save) and exit without writing state
+--version | -version   Print version and exit
+```
+Run `./bin/agentcli -h` to see the built‑in help.
+
+### Image generation flags
+
+The following flags control the Images API behavior used by the assistant when generating images. Precedence is always: flags > environment > inheritance > default.
+
+| Flag | Environment | Default / Inheritance | Description |
+|---|---|---|---|
+| `-image-base-url string` | `OAI_IMAGE_BASE_URL` | Inherits `-base-url` | Image API base URL |
+| `-image-api-key string` | `OAI_IMAGE_API_KEY` | Inherits `-api-key`; falls back to `OPENAI_API_KEY` | API key for Images API |
+| `-image-model string` | `OAI_IMAGE_MODEL` | `gpt-image-1` | Images model ID |
+| `-image-http-timeout duration` | `OAI_IMAGE_HTTP_TIMEOUT` | Inherits `-http-timeout` | HTTP timeout for image requests |
+| `-image-http-retries int` | `OAI_IMAGE_HTTP_RETRIES` | Inherits `-http-retries` | Retry attempts for transient image HTTP errors |
+| `-image-http-retry-backoff duration` | `OAI_IMAGE_HTTP_RETRY_BACKOFF` | Inherits `-http-retry-backoff` | Base backoff for image HTTP retries |
+| `-image-n int` | `OAI_IMAGE_N` | `1` | Number of images to generate |
+| `-image-size string` | `OAI_IMAGE_SIZE` | `1024x1024` | Size WxH |
+| `-image-quality string` | `OAI_IMAGE_QUALITY` | `standard` | `standard` or `hd` |
+| `-image-style string` | `OAI_IMAGE_STYLE` | `natural` | `natural` or `vivid` |
+| `-image-response-format string` | `OAI_IMAGE_RESPONSE_FORMAT` | `url` | `url` or `b64_json` |
+| `-image-transparent-background` | `OAI_IMAGE_TRANSPARENT_BACKGROUND` | `false` | Request transparent background when supported |
+
+### Why you usually don’t need to change knobs
+- The default `-temp 1.0` is standardized for broad provider/model parity and GPT‑5 compatibility.
+- The one‑knob rule applies: if you set `-top-p`, the agent omits `temperature`; otherwise it sends `temperature` (default 1.0) and leaves `top_p` unset.
+- The one‑knob rule applies for both stages: if you set `-top-p` (or `-prep-top-p`), the agent omits `temperature` for that stage; otherwise it sends `temperature` (default 1.0) when supported. Pre‑stage profiles are available via `-prep-profile`, e.g. `deterministic` sets temperature to 0.1 when supported.
+- See the policy for details and rationale: [ADR‑0004: Default LLM policy](docs/adr/0004-default-llm-policy.md).
+
+### Capabilities
+List enabled tools from a manifest without running the agent. The output includes a prominent header warning, and certain tools like `img_create` are annotated with an extra warning because they make outbound network calls and can save files:
+```bash
+./bin/agentcli -tools ./tools.json -capabilities
+```
+
+## Examples
+### Zero-config with GPT-5
+Run against a GPT‑5 compatible endpoint without tuning sampling knobs. The CLI sends `temperature: 1.0` by default for models that support it.
+```bash
+./bin/agentcli -prompt "Say ok" -model gpt-5 -base-url "$OAI_BASE_URL" -api-key "$OAI_API_KEY" -max-steps 1 -debug
+# stderr will include a request dump containing "\"temperature\": 1"
+```
+
+### Tool calls transcript
+Minimal JSON transcript showing correct tool‑call sequencing:
+```json
+[
+  {"role":"user","content":"What's the local time in Helsinki?"},
+  {
+    "role":"assistant",
+    "content":null,
+    "tool_calls":[
+      {
+        "id":"call_get_time_1",
+        "type":"function",
+        "function":{
+          "name":"get_time",
+          "arguments":"{\"timezone\":\"Europe/Helsinki\"}"
+        }
+      }
+    ]
+  },
+  {
+    "role":"tool",
+    "tool_call_id":"call_get_time_1",
+    "name":"get_time",
+    "content":"{\"timezone\":\"Europe/Helsinki\",\"iso\":\"2025-08-17T12:34:56Z\",\"unix\":1755424496}"
+  },
+  {"role":"assistant","content":"It's 15:34 in Helsinki."}
+]
+```
+Notes:
+- For parallel tool calls (multiple entries in `tool_calls`), append one `role:"tool"` message per `id` before calling the API again. Order of tool messages is not significant as long as each `tool_call_id` is present exactly once.
+- Transcript hygiene: when running without `-debug`, the CLI replaces any single tool message content larger than 8 KiB with `{"truncated":true,"reason":"large-tool-output"}` before sending to the API. Use `-debug` to inspect full payloads during troubleshooting.
+
+### Worked example: tool calls and transcript
+See `examples/tool_calls.md` for a self-contained, test-driven worked example that:
+- Exercises default temperature 1.0
+- Demonstrates a two-tool-call interaction with matching `tool_call_id`
+- Captures a transcript via `-debug` showing request/response JSON dumps
+
+Run the example test:
+```bash
+go test ./examples -run TestWorkedExample_ToolCalls_TemperatureOne_Sequencing -v
+```
+
+### Split backends for chat and image
+
+Use one provider for chat and another for image generation by overriding the image backend only:
+
+```bash
+export OAI_BASE_URL=https://api.example-chat.local/v1
+export OAI_API_KEY=chat-key
+
+./bin/agentcli \
+  -prompt "Create a simple logo" \
+  -tools ./tools.json \
+  -image-base-url https://api.openai.com/v1 \
+  -image-api-key "$OPENAI_API_KEY" \
+  -image-model gpt-image-1 \
+  -image-size 1024x1024
+```
+
+### View refined messages (pre-stage and final)
+See also ADR‑0005 for the pre‑stage flow and channel routing details: `docs/adr/0005-harmony-pre-processing-and-channel-aware-output.md`.
+Inspect message arrays deterministically without running the full loop:
+
+```bash
+# Pre-stage only: print refined Harmony messages and exit
+./bin/agentcli -prompt "Say ok" -prep-dry-run | jq .
+
+# Before the main call: pretty-print merged messages to stderr, then proceed
+./bin/agentcli -prompt "Say ok" -print-messages 2> >(jq .)
+```
+
+### Exec tool
+Build the exec tool and run a simple command (Unix):
+```bash
+make build-tools
+echo '{"cmd":"/bin/echo","args":["hello"]}' | ./tools/bin/exec
+# => {"exitCode":0,"stdout":"hello\n","stderr":"","durationMs":<n>}
+```
+Timeout example:
+```bash
+echo '{"cmd":"/bin/sleep","args":["2"],"timeoutSec":1}' | ./tools/bin/exec
+# => non-zero exit, stderr contains "timeout"
+```
+
+### Filesystem tools
+The following examples assume `make build-tools` has produced binaries into `tools/bin/*`.
+
+#### fs_read_file
+```bash
+make build-tools
+printf 'hello world' > tmp_readme_demo.txt
+echo '{"path":"tmp_readme_demo.txt"}' | ./tools/bin/fs_read_file | jq .
+rm -f tmp_readme_demo.txt
+```
+
+#### fs_append_file
+```bash
+make build-tools
+echo -n 'hello ' | base64 > b64a.txt
+echo -n 'world'  | base64 > b64b.txt
+echo '{"path":"tmp_append_demo.txt","contentBase64":"'"$(cat b64a.txt)"'"}' | ./tools/bin/fs_append_file | jq .
+echo '{"path":"tmp_append_demo.txt","contentBase64":"'"$(cat b64b.txt)"'"}' | ./tools/bin/fs_append_file | jq .
+cat tmp_append_demo.txt; rm -f tmp_append_demo.txt b64a.txt b64b.txt
+```
+
+#### fs_write_file
+```bash
+make build-tools
+echo -n 'hello world' | base64 > b64.txt
+echo '{"path":"tmp_write_demo.txt","contentBase64":"'"$(cat b64.txt)"'"}' | ./tools/bin/fs_write_file | jq .
+cat tmp_write_demo.txt; rm -f tmp_write_demo.txt b64.txt
+```
+
+#### fs_mkdirp
+```bash
+make build-tools
+echo '{"path":"tmp_mkdirp_demo/a/b/c","modeOctal":"0755"}' | ./tools/bin/fs_mkdirp | jq .
+ls -ld tmp_mkdirp_demo/a/b/c
+echo '{"path":"tmp_mkdirp_demo/a/b/c","modeOctal":"0755"}' | ./tools/bin/fs_mkdirp | jq .
+rm -rf tmp_mkdirp_demo
+```
+
+#### fs_rm
+```bash
+make build-tools
+printf 'temp' > tmp_rm_demo.txt
+echo '{"path":"tmp_rm_demo.txt"}' | ./tools/bin/fs_rm | jq .
+mkdir -p tmp_rm_dir/a/b && touch tmp_rm_dir/a/b/file.txt
+echo '{"path":"tmp_rm_dir","recursive":true}' | ./tools/bin/fs_rm | jq .
+rm -rf tmp_rm_dir
+```
+
+#### fs_move
+```bash
+make build-tools
+printf 'payload' > tmp_move_src.txt
+echo '{"from":"tmp_move_src.txt","to":"tmp_move_dst.txt"}' | ./tools/bin/fs_move | jq .
+printf 'old' > tmp_move_dst.txt; printf 'new' > tmp_move_src.txt
+echo '{"from":"tmp_move_src.txt","to":"tmp_move_dst.txt","overwrite":true}' | ./tools/bin/fs_move | jq .
+rm -f tmp_move_src.txt tmp_move_dst.txt
+```
+
+#### fs_listdir
+```bash
+make build-tools
+mkdir -p tmp_listdir_demo/a b && touch tmp_listdir_demo/.hidden tmp_listdir_demo/a/afile tmp_listdir_demo/bfile
+echo '{"path":"tmp_listdir_demo"}' | ./tools/bin/fs_listdir | jq '.entries | map(.path)'
+jq -n '{path:"tmp_listdir_demo",recursive:true,globs:["**/*"],includeHidden:false}' | ./tools/bin/fs_listdir | jq '.entries | map(select(.type=="file") | .path)'
+rm -rf tmp_listdir_demo
+```
+
+#### fs_apply_patch
+```bash
+make build-tools
+cat > /tmp/demo.diff <<'EOF'
+--- /dev/null
++++ b/tmp_patch_demo.txt
+@@ -0,0 +1,2 @@
++hello
++world
+EOF
+jq -n --arg d "$(cat /tmp/demo.diff)" '{unifiedDiff:$d}' | ./tools/bin/fs_apply_patch | jq .
+printf 'hello
+world
+' | diff -u - tmp_patch_demo.txt && echo OK
+```
+
+#### fs_edit_range
+```bash
+make build-tools
+printf 'abcdef' > tmp_edit_demo.txt
+echo -n 'XY' | base64 > b64.txt
+jq -n --arg b "$(cat b64.txt)" '{path:"tmp_edit_demo.txt",startByte:2,endByte:4,replacementBase64:$b}' | ./tools/bin/fs_edit_range | jq .
+cat tmp_edit_demo.txt # => abXYef
+rm -f tmp_edit_demo.txt b64.txt
+```
+
+#### fs_stat
+```bash
+make build-tools
+printf 'hello world' > tmp_stat_demo.txt
+echo '{"path":"tmp_stat_demo.txt","hash":"sha256"}' | ./tools/bin/fs_stat | jq .
+rm -f tmp_stat_demo.txt
+```
+
+### Image generation tool (img_create)
+
+Generate images via an OpenAI‑compatible Images API and save files into your repository (default) or return base64 on demand.
+
+Quickstart (Unix/macOS/Windows via `make build-tools`):
+
+```bash
+make build-tools
+```
+
+Minimal `tools.json` entry (copy/paste next to your binary):
+
+```json
+{
+  "tools": [
+    {
+      "name": "img_create",
+      "description": "Generate image(s) with OpenAI Images API and save to repo or return base64",
+      "schema": {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+          "prompt": {"type": "string"},
+          "n": {"type": "integer", "minimum": 1, "maximum": 4, "default": 1},
+          "size": {"type": "string", "pattern": "^\\d{3,4}x\\d{3,4}$", "default": "1024x1024"},
+          "model": {"type": "string", "default": "gpt-image-1"},
+          "return_b64": {"type": "boolean", "default": false},
+          "save": {
+            "type": "object",
+            "required": ["dir"],
+            "properties": {
+              "dir": {"type": "string"},
+              "basename": {"type": "string", "default": "img"},
+              "ext": {"type": "string", "enum": ["png"], "default": "png"}
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/img_create"],
+      "timeoutSec": 120,
+      "envPassthrough": ["OAI_API_KEY", "OAI_BASE_URL", "OAI_IMAGE_BASE_URL", "OAI_HTTP_TIMEOUT"]
+    }
+  ]
+}
+```
+
+Run the agent with a prompt that instructs the assistant to call `img_create` and save under `assets/`:
+
+```bash
+export OAI_BASE_URL=${OAI_BASE_URL:-https://api.openai.com/v1}
+export OAI_API_KEY=your-key
+
+./bin/agentcli \
+  -tools ./tools.json \
+  -prompt "Generate a tiny illustrative image using img_create and save it under assets/ with basename banner" \
+  -debug
+
+# Expect: one or more PNGs under assets/ (e.g., assets/banner_001.png) and a concise final message on stdout
+```
+
+Notes:
+- By default, the tool writes image files and does not include base64 in transcripts, avoiding large payloads.
+- To return base64 instead, pass `{ "return_b64": true }` to the tool; base64 is elided in stdout unless `IMG_CREATE_DEBUG_B64=1` or `DEBUG_B64=1` is set.
+- Windows: the built binary is `./tools/bin/img_create.exe` and `tools.json` should reference the `.exe`.
+- See Troubleshooting for network/API issues and timeouts: `docs/runbooks/troubleshooting.md`.
+
+#### fs_search
+```bash
+make build-tools
+mkdir -p tmp_search_demo && printf 'alpha\nbeta\ngamma\n' > tmp_search_demo/sample.txt
+jq -n '{query:"^ga",globs:["**/*.txt"],regex:true}' | ./tools/bin/fs_search | jq '.matches'
+rm -rf tmp_search_demo
+```
+
+## Security
+- Tools are an explicit allowlist from `tools.json`
+- No shell interpretation; commands executed via argv only
+- JSON contract on stdin/stdout; strict timeouts per call
+- Treat model output as untrusted input; never pass it to a shell
+
+See the full threat model in `docs/security/threat-model.md`.
+
+### Unrestricted tools warning
+- Enabling `exec` grants arbitrary command execution and may allow full network access. Treat this as remote code execution.
+- Run the CLI and tools in a sandboxed environment (container/jail/VM) with least privilege.
+- Keep `tools.json` minimal and audited. Do not pass secrets via tool arguments; prefer environment variables or CI secret stores.
+- Audit log redaction: set `GOAGENT_REDACT` to mask sensitive values in audit entries. `OAI_API_KEY`/`OPENAI_API_KEY` are always masked if present.
+
+## State persistence (-state-dir)
+
+Persist and restore execution state to make repeated runs deterministic and faster.
+
+- Enable by passing `-state-dir <dir>` (or `AGENTCLI_STATE_DIR`). The directory must be private (`0700`).
+- On first run, the CLI saves a snapshot `state-<RFC3339UTC>-<8charSHA>.json` and a pointer file `latest.json`.
+- On subsequent runs with the same scope, the CLI restores prompts/settings and skips pre-stage unless `-state-refine` is provided.
+- Partition contexts with `-state-scope` (or `AGENTCLI_STATE_SCOPE`); when unset, a default scope is derived from model, base URL, and toolset.
+- Inspect actions without touching disk using `-dry-run`.
+
+Examples:
+
+```bash
+# First run saves a snapshot
+./bin/agentcli -prompt "Say ok" -tools ./tools.json -state-dir "$PWD/.agent-state"
+
+# Restore and skip pre-stage
+./bin/agentcli -prompt "Say ok" -tools ./tools.json -state-dir "$PWD/.agent-state"
+
+# Refine existing state with inline text
+./bin/agentcli -prompt "Say ok" -state-dir "$PWD/.agent-state" -state-refine -state-refine-text "Tighten tone"
+
+# Use a custom scope to keep contexts separate
+./bin/agentcli -prompt "Say ok" -state-dir "$PWD/.agent-state" -state-scope docs-demo
+```
+
+See ADR‑0012 for rationale and details: `docs/adr/0012-state-dir-persistence.md`.
+
+## Troubleshooting
+Common issues and deterministic fixes are documented with copy‑paste commands in `docs/runbooks/troubleshooting.md`.
+
+## Documentation
+Start with the [Documentation index](docs/README.md) for design docs, ADRs, and references:
+- [Tools manifest reference](docs/reference/tools-manifest.md)
+- [Research tools reference](docs/reference/research-tools.md)
+- [CLI reference](docs/reference/cli-reference.md)
+- [Interface: code.sandbox.js.run](docs/interfaces/code.sandbox.js.run.md)
+- [Architecture: Module boundaries](docs/architecture/module-boundaries.md)
+- [Security: Threat model](docs/security/threat-model.md)
+- [ADR‑0005: Harmony pre‑processing and channel‑aware output](docs/adr/0005-harmony-pre-processing-and-channel-aware-output.md)
+- [Pre-stage Harmony output contract](docs/harmony-prestage.md)
+- [ADR‑0006: Image generation tool (img_create)](docs/adr/0006-image-generation-tool-img_create.md)
+- [ADR‑0010: Adopt SearXNG & network research toolbelt (CLI-only)](docs/adr/0010-research-tools-searxng.md)
+
+## Diagrams
+- Agent loop: `docs/diagrams/agentcli-seq.md`
+- Toolbelt interactions: `docs/diagrams/toolbelt-seq.md`
+- Pre‑stage flow: `docs/diagrams/harmony-prep-seq.md`
+
+## Tests
+Run the full test suite (offline):
+```bash
+go test ./...
+```
+Lint, vet, and formatting checks:
+```bash
+make lint
+make fmt   # apply gofmt -s -w to the repo
+```
+
+Guarded logs cleanup:
+```bash
+# Only removes ./logs when ./logs/STATE trimmed equals DOWN
+make clean-logs
+
+# End-to-end verification of the guard logic (creates temp dirs)
+make test-clean-logs
+```
+
+Reproducible builds: the `Makefile` uses `-trimpath` and stripped `-ldflags` with VCS stamping disabled so two clean builds produce identical binaries. Verify locally by running two consecutive `make clean build build-tools` and comparing `sha256sum` outputs.
+
+## Contributing
+Contributions are welcome! See `CONTRIBUTING.md` for workflow, coding standards, and how to run quality gates locally. Please also read `CODE_OF_CONDUCT.md`.
+
+Useful local helpers during development:
+- `make check-tools-paths` — enforce canonical `tools/cmd/NAME` sources and `tools/bin/NAME` invocations (requires `rg`)
+- `make verify-manifest-paths` — ensure relative `tools.json` commands use `./tools/bin/NAME` (absolute allowed in tests)
+- `make build-tool NAME=<name>` — build a single tool binary into `tools/bin/NAME`
+- `make check-go-version` — fail fast if your local Go major.minor differs from `go.mod`
+
+If your local toolchain does not match, you will see:
+```text
+Go toolchain mismatch: system X.Y != go.mod X.Y
+```
+Remediation: install the matching Go version shown by `go.mod` (e.g., from the official downloads) or switch via your version manager, then rerun `make check-go-version`.
+
+## Tooling
+
+This repository pins the toolchain for deterministic results:
+- CI uses the Go version declared in `go.mod` across all OS jobs.
+- Linting is performed with a pinned `golangci-lint` version managed by the `Makefile`.
+
+See ADR‑0003 for the full policy and rationale: [docs/adr/0003-toolchain-and-lint-policy.md](docs/adr/0003-toolchain-and-lint-policy.md).
+
+## Support
+- Open an issue on the tracker: [Issues](https://github.com/hyperifyio/goagent/issues)
+  - For security concerns, avoid posting secrets in logs. If a private report is needed, open an issue with minimal detail and a maintainer will reach out.
+ - Follow updates from the author on LinkedIn: [Jaakko Heusala](https://www.linkedin.com/in/jheusala/)
+
+## Roadmap
+Planned improvements and open ideas are tracked in `FUTURE_CHECKLIST.md`. Larger architectural decisions are recorded under `docs/adr/` (see ADR‑0001 and ADR‑0002). Contributions to the roadmap are welcome via issues and PRs.
+
+## Project status
+Experimental, but actively maintained. Interfaces may change before a stable 1.0.
+
+## License and credits
+MIT license. See `LICENSE`.
+
+Maintainers and authors:
+- Hyperify.io maintainers
+- Primary author: Jaakko Heusala
+
+Acknowledgements: inspired by OpenAI‑compatible agent patterns; built for portability and safety.
+
+## Changelog
+See `CHANGELOG.md` for notable changes and release notes.
+
+## More examples
+See `examples/unrestricted.md` for copy‑paste prompts demonstrating `exec` + file tools to write, build, and run code in a sandboxed environment.

--- a/tools.json
+++ b/tools.json
@@ -1,0 +1,517 @@
+{
+  "tools": [
+    {
+      "name": "get_time",
+      "description": "Get current time for an IANA timezone",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone, e.g. Europe/Helsinki"
+          },
+          "tz": {
+            "type": "string",
+            "description": "Alias for timezone (deprecated)"
+          }
+        },
+        "required": ["timezone"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/get_time"],
+      "timeoutSec": 5
+    }
+    ,
+    {
+      "name": "http_fetch",
+      "description": "Safe HTTP/HTTPS fetcher with byte cap and redirects",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "url": {"type": "string"},
+          "method": {"type": "string", "enum": ["GET", "HEAD"]},
+          "max_bytes": {"type": "integer", "minimum": 1, "default": 1048576},
+          "timeout_ms": {"type": "integer", "minimum": 1, "default": 10000},
+          "decompress": {"type": "boolean", "default": true}
+        },
+        "required": ["url"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/http_fetch"],
+      "timeoutSec": 15,
+      "envPassthrough": ["HTTP_TIMEOUT_MS"]
+    }
+    ,
+    {
+      "name": "fs_read_file",
+      "description": "Read a repository-relative file as base64 with optional offset and max bytes",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string", "description": "Repo-relative path to file"},
+          "offsetBytes": {"type": "integer", "minimum": 0},
+          "maxBytes": {"type": "integer", "minimum": 1}
+        },
+        "required": ["path"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_read_file"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_write_file",
+      "description": "Atomically write a repository-relative file from base64 content",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "contentBase64": {"type": "string"},
+          "createModeOctal": {"type": "string"}
+        },
+        "required": ["path", "contentBase64"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_write_file"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_append_file",
+      "description": "Append base64 content to a repository-relative file (create if missing)",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "contentBase64": {"type": "string"}
+        },
+        "required": ["path", "contentBase64"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_append_file"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_mkdirp",
+      "description": "Recursively create a directory path",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "modeOctal": {"type": "string"}
+        },
+        "required": ["path"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_mkdirp"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_rm",
+      "description": "Remove a repository-relative file or directory",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "recursive": {"type": "boolean"},
+          "force": {"type": "boolean"}
+        },
+        "required": ["path"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_rm"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_move",
+      "description": "Move or rename a repository-relative path",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "from": {"type": "string"},
+          "to": {"type": "string"},
+          "overwrite": {"type": "boolean"}
+        },
+        "required": ["from", "to"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_move"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_search",
+      "description": "Search repository files for a query with optional regex/globs",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "query": {"type": "string"},
+          "regex": {"type": "boolean"},
+          "globs": {"type": "array", "items": {"type": "string"}},
+          "maxResults": {"type": "integer", "minimum": 1}
+        },
+        "required": ["query"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_search"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_listdir",
+      "description": "List directory entries with optional recursion and glob filtering",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "recursive": {"type": "boolean"},
+          "globs": {"type": "array", "items": {"type": "string"}},
+          "includeHidden": {"type": "boolean"},
+          "maxResults": {"type": "integer", "minimum": 1}
+        },
+        "required": ["path"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_listdir"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_read_lines",
+      "description": "Read a line range from a repository-relative file with optional byte cap",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "startLine": {"type": "integer", "minimum": 0},
+          "endLine": {"type": "integer", "minimum": 0},
+          "maxBytes": {"type": "integer", "minimum": 1}
+        },
+        "required": ["path", "startLine", "endLine"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_read_lines"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_apply_patch",
+      "description": "Apply a strict unified diff (optional dry-run)",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "unifiedDiff": {"type": "string"},
+          "dryRun": {"type": "boolean"}
+        },
+        "required": ["unifiedDiff"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_apply_patch"],
+      "timeoutSec": 10
+    },
+    {
+      "name": "fs_edit_range",
+      "description": "Atomically replace a byte range in a file with base64 content",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "startByte": {"type": "integer", "minimum": 0},
+          "endByte": {"type": "integer", "minimum": 0},
+          "replacementBase64": {"type": "string"},
+          "expectedSha256": {"type": "string"}
+        },
+        "required": ["path", "startByte", "endByte", "replacementBase64"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_edit_range"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "exec",
+      "description": "Run an arbitrary program with args, cwd, env, and stdin",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cmd": {"type": "string"},
+          "args": {"type": "array", "items": {"type": "string"}},
+          "cwd": {"type": "string"},
+          "env": {"type": "object", "additionalProperties": {"type": "string"}},
+          "stdin": {"type": "string"},
+          "timeoutSec": {"type": "integer", "minimum": 1}
+        },
+        "required": ["cmd"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/exec"],
+      "timeoutSec": 30
+    },
+    {
+      "name": "fs_stat",
+      "description": "Stat a path (optionally follow symlinks and compute hash)",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "followSymlinks": {"type": "boolean"},
+          "hash": {"type": "string", "enum": ["none", "sha256"]}
+        },
+        "required": ["path"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_stat"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "img_create",
+      "description": "Generate image(s) with OpenAI Images API and save to repo or return base64",
+      "schema": {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+          "prompt": {"type": "string"},
+          "n": {"type": "integer", "minimum": 1, "maximum": 4, "default": 1},
+          "size": {"type": "string", "pattern": "^\\d{3,4}x\\d{3,4}$", "default": "1024x1024"},
+          "model": {"type": "string", "default": "gpt-image-1"},
+          "return_b64": {"type": "boolean", "default": false},
+          "save": {
+            "type": "object",
+            "required": ["dir"],
+            "properties": {
+              "dir": {"type": "string"},
+              "basename": {"type": "string", "default": "img"},
+              "ext": {"type": "string", "enum": ["png"], "default": "png"}
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/img_create"],
+      "timeoutSec": 120,
+      "envPassthrough": ["OAI_API_KEY", "OAI_BASE_URL", "OAI_IMAGE_BASE_URL", "OAI_HTTP_TIMEOUT"]
+    },
+    {
+      "name": "searxng_search",
+      "description": "Meta search via SearXNG",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "q": {"type": "string"},
+          "time_range": {"type": "string", "enum": ["day","week","month","year"]},
+          "categories": {"type": "array", "items": {"type": "string"}},
+          "engines": {"type": "array", "items": {"type": "string"}},
+          "language": {"type": "string"},
+          "page": {"type": "integer", "minimum": 1},
+          "size": {"type": "integer", "minimum": 1, "maximum": 50}
+        },
+        "required": ["q"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/searxng_search"],
+      "timeoutSec": 15,
+      "envPassthrough": ["SEARXNG_BASE_URL","HTTP_TIMEOUT_MS"]
+    }
+    ,
+    {
+      "name": "robots_check",
+      "description": "Evaluate robots.txt for a given URL and user agent",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "url": {"type": "string"},
+          "user_agent": {"type": "string"}
+        },
+        "required": ["url"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/robots_check"],
+      "timeoutSec": 10
+    }
+    ,
+    {
+      "name": "readability_extract",
+      "description": "Extract article content from HTML using go-readability",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "html": {"type": "string"},
+          "base_url": {"type": "string"}
+        },
+        "required": ["html", "base_url"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/readability_extract"],
+      "timeoutSec": 10
+    }
+    ,
+    {
+      "name": "metadata_extract",
+      "description": "Extract OpenGraph, Twitter cards, and JSON-LD from HTML",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "html": {"type": "string"},
+          "base_url": {"type": "string"}
+        },
+        "required": ["html", "base_url"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/metadata_extract"],
+      "timeoutSec": 10
+    }
+    ,
+    {
+      "name": "pdf_extract",
+      "description": "Extract text from PDF pages; optional OCR via tesseract",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "pdf_base64": {"type": "string"},
+          "pages": {"type": "array", "items": {"type": "integer"}}
+        },
+        "required": ["pdf_base64"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/pdf_extract"],
+      "timeoutSec": 60,
+      "envPassthrough": ["ENABLE_OCR"]
+    }
+    ,
+    {
+      "name": "rss_fetch",
+      "description": "Fetch and parse RSS/Atom feeds with conditional GET",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "url": {"type": "string"},
+          "if_modified_since": {"type": "string"}
+        },
+        "required": ["url"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/rss_fetch"],
+      "timeoutSec": 10
+    }
+    ,
+    {
+      "name": "wayback_lookup",
+      "description": "Query Internet Archive Wayback Machine for closest snapshot; optionally trigger save",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "url": {"type": "string"},
+          "save": {"type": "boolean", "default": false}
+        },
+        "required": ["url"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/wayback_lookup"],
+      "timeoutSec": 10
+    }
+    ,
+    {
+      "name": "wiki_query",
+      "description": "MediaWiki summaries/search",
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "titles": {
+            "type": "string",
+            "description": "Exact page title to fetch summary for (mutually exclusive with 'search')"
+          },
+          "search": {
+            "type": "string",
+            "description": "Full-text search term to find pages (mutually exclusive with 'titles')"
+          },
+          "language": {
+            "type": "string",
+            "default": "en",
+            "description": "MediaWiki language code, e.g. en, fi"
+          }
+        }
+      },
+      "command": ["./tools/bin/wiki_query"],
+      "timeoutSec": 10
+    }
+    ,
+    {
+      "name": "openalex_search",
+      "description": "Search scholarly works via OpenAlex",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "q": {"type": "string"},
+          "from": {"type": "string"},
+          "to": {"type": "string"},
+          "per_page": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10}
+        },
+        "required": ["q"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/openalex_search"],
+      "timeoutSec": 15
+    }
+    ,
+    {
+      "name": "crossref_search",
+      "description": "Search DOI metadata via Crossref",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "q": {"type": "string"},
+          "rows": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10}
+        },
+        "required": ["q"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/crossref_search"],
+      "timeoutSec": 15,
+      "envPassthrough": ["CROSSREF_MAILTO", "HTTP_TIMEOUT_MS"]
+    }
+    ,
+    {
+      "name": "github_search",
+      "description": "Search GitHub repositories, code, issues, or commits",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "q": {"type": "string"},
+          "type": {"type": "string", "enum": ["repositories", "code", "issues", "commits"]},
+          "per_page": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10}
+        },
+        "required": ["q", "type"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/github_search"],
+      "timeoutSec": 15,
+      "envPassthrough": ["GITHUB_TOKEN"]
+    }
+    ,
+    {
+      "name": "citation_pack",
+      "description": "Normalize a citation and optionally include Wayback archive URL",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "doc": {
+            "type": "object",
+            "properties": {
+              "title": {"type": "string"},
+              "url": {"type": "string"},
+              "published_at": {"type": "string"}
+            },
+            "required": ["url"],
+            "additionalProperties": false
+          },
+          "archive": {
+            "type": "object",
+            "properties": {
+              "wayback": {"type": "boolean"}
+            },
+            "additionalProperties": false
+          }
+        },
+        "required": ["doc"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/citation_pack"],
+      "timeoutSec": 10
+    }
+  ]
+}

--- a/tools/cmd/get_time/get_time.go
+++ b/tools/cmd/get_time/get_time.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+type input struct {
+	Timezone string `json:"timezone"`
+	// Backward-compatible alias
+	TZ string `json:"tz"`
+}
+
+type output struct {
+	Timezone string `json:"timezone"`
+	ISO8601  string `json:"iso8601"`
+}
+
+func main() {
+	inBytes, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "{\"error\":\"read stdin: %s\"}\n", escape(err.Error()))
+		os.Exit(1)
+	}
+	var in input
+	if len(strings.TrimSpace(string(inBytes))) == 0 {
+		inBytes = []byte("{}")
+	}
+	if err := json.Unmarshal(inBytes, &in); err != nil {
+		fmt.Fprintf(os.Stderr, "{\"error\":\"bad json: %s\"}\n", escape(err.Error()))
+		os.Exit(1)
+	}
+	// Prefer canonical 'timezone'; allow backward-compatible alias 'tz'
+	if strings.TrimSpace(in.Timezone) == "" && strings.TrimSpace(in.TZ) != "" {
+		in.Timezone = in.TZ
+	}
+	if strings.TrimSpace(in.Timezone) == "" {
+		fmt.Fprintf(os.Stderr, "{\"error\":\"missing timezone\"}\n")
+		os.Exit(1)
+	}
+	loc, err := time.LoadLocation(in.Timezone)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "{\"error\":\"invalid timezone: %s\"}\n", escape(err.Error()))
+		os.Exit(1)
+	}
+	now := time.Now().In(loc).Format(time.RFC3339)
+	out := output{Timezone: in.Timezone, ISO8601: now}
+	b, err := json.Marshal(out)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "{\"error\":\"marshal: %s\"}\n", escape(err.Error()))
+		os.Exit(1)
+	}
+	if _, err := os.Stdout.Write(append(b, '\n')); err != nil {
+		fmt.Fprintf(os.Stderr, "{\"error\":\"write stdout: %s\"}\n", escape(err.Error()))
+		os.Exit(1)
+	}
+}
+
+func escape(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\"", "\\\"")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return s
+}

--- a/tools/cmd/get_time/get_time_test.go
+++ b/tools/cmd/get_time/get_time_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	testutil "github.com/hyperifyio/goagent/tools/testutil"
+)
+
+type timeOutput struct {
+	Timezone string `json:"timezone"`
+	ISO8601  string `json:"iso8601"`
+}
+
+func runTimeTool(t *testing.T, bin string, input any) (timeOutput, string, int) {
+	t.Helper()
+	b, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("marshal input: %v", err)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(b)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	code := 0
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			code = ee.ExitCode()
+		} else {
+			code = 1
+		}
+	}
+	var out timeOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout.String())), &out); err != nil && code == 0 {
+		t.Fatalf("unmarshal stdout: %v; raw=%q", err, stdout.String())
+	}
+	return out, stderr.String(), code
+}
+
+func TestTimeCLI_AcceptsTimezoneAndOutputsISO8601(t *testing.T) {
+	bin := testutil.BuildTool(t, "get_time")
+	out, stderr, code := runTimeTool(t, bin, map[string]any{"timezone": "UTC"})
+	if code != 0 {
+		t.Fatalf("expected success, got exit=%d stderr=%q", code, stderr)
+	}
+	if out.Timezone != "UTC" || out.ISO8601 == "" {
+		t.Fatalf("unexpected output: %+v", out)
+	}
+	if _, err := time.Parse(time.RFC3339, out.ISO8601); err != nil {
+		t.Fatalf("iso8601 not RFC3339: %v", err)
+	}
+}
+
+func TestTimeCLI_AcceptsAliasTZ(t *testing.T) {
+	bin := testutil.BuildTool(t, "get_time")
+	out, stderr, code := runTimeTool(t, bin, map[string]any{"tz": "Europe/Helsinki"})
+	if code != 0 {
+		t.Fatalf("expected success, got exit=%d stderr=%q", code, stderr)
+	}
+	if out.Timezone != "Europe/Helsinki" || out.ISO8601 == "" {
+		t.Fatalf("unexpected output: %+v", out)
+	}
+	if _, err := time.Parse(time.RFC3339, out.ISO8601); err != nil {
+		t.Fatalf("iso8601 not RFC3339: %v", err)
+	}
+}
+
+func TestTimeCLI_MissingTimezone_ErrorContract(t *testing.T) {
+	bin := testutil.BuildTool(t, "get_time")
+	out, stderr, code := runTimeTool(t, bin, map[string]any{})
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for missing timezone, got 0; stderr=%q", stderr)
+	}
+	if out.Timezone != "" || out.ISO8601 != "" {
+		t.Fatalf("stdout should be empty on error, got: %+v", out)
+	}
+	s := strings.TrimSpace(stderr)
+	if s == "" || !strings.Contains(s, "\"error\"") {
+		t.Fatalf("stderr should contain JSON error, got: %q", stderr)
+	}
+}
+
+func TestTimeCLI_InvalidTimezone_ErrorContract(t *testing.T) {
+	bin := testutil.BuildTool(t, "get_time")
+	out, stderr, code := runTimeTool(t, bin, map[string]any{"timezone": "Not/AZone"})
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for invalid timezone, got 0; stderr=%q", stderr)
+	}
+	if out.Timezone != "" || out.ISO8601 != "" {
+		t.Fatalf("stdout should be empty on error, got: %+v", out)
+	}
+	s := strings.TrimSpace(stderr)
+	if s == "" || !strings.Contains(s, "\"error\"") {
+		t.Fatalf("stderr should contain JSON error, got: %q", stderr)
+	}
+}
+
+func TestToolbeltDiagramExists(t *testing.T) {
+	if _, err := os.Stat("../../../docs/diagrams/toolbelt-seq.md"); err != nil {
+		t.Fatalf("missing docs/diagrams/toolbelt-seq.md: %v", err)
+	}
+}

--- a/tools/testutil/buildtool.go
+++ b/tools/testutil/buildtool.go
@@ -1,0 +1,86 @@
+package testutil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// BuildTool builds the named tool binary into a test-scoped temporary
+// directory and returns the absolute path to the produced executable.
+//
+// Source discovery (absolute paths used to satisfy repository path hygiene
+// rules in linters/tests):
+//   - tools/cmd/<name> (canonical layout only)
+func BuildTool(t *testing.T, name string) string {
+	t.Helper()
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("find repo root: %v", err)
+	}
+
+	// Determine binary name with OS suffix
+	binName := name
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	outPath := filepath.Join(t.TempDir(), binName)
+
+	// Candidate source locations (canonical layout only)
+	var candidates []string
+	candidates = append(candidates, filepath.Join(repoRoot, "tools", "cmd", name))
+
+	var srcPath string
+	for _, c := range candidates {
+		if fi, statErr := os.Stat(c); statErr == nil {
+			// Accept directories and regular files
+			if fi.IsDir() || fi.Mode().IsRegular() {
+				srcPath = c
+				break
+			}
+		}
+	}
+	if srcPath == "" {
+		t.Fatalf("tool sources not found for %q under %s", name, filepath.Join(repoRoot, "tools"))
+	}
+
+	cmd := exec.Command("go", "build", "-o", outPath, srcPath)
+	cmd.Dir = repoRoot
+	// Inherit environment; ensure CGO disabled for determinism
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build %s from %s failed: %v\n%s", name, relOrSame(repoRoot, srcPath), err, string(output))
+	}
+	return outPath
+}
+
+func findRepoRoot() (string, error) {
+	// Start from CWD and walk up until go.mod is found
+	start, err := os.Getwd()
+	if err != nil || start == "" {
+		return "", errors.New("cannot determine working directory")
+	}
+	dir := start
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found from %s upward", start)
+		}
+		dir = parent
+	}
+}
+
+func relOrSame(base, target string) string {
+	if rel, err := filepath.Rel(base, target); err == nil {
+		return rel
+	}
+	return target
+}

--- a/tools/testutil/buildtool_test.go
+++ b/tools/testutil/buildtool_test.go
@@ -1,0 +1,21 @@
+package testutil
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBuildTool_WindowsSuffix(t *testing.T) {
+	// Use a real tool name to ensure build succeeds across environments.
+	path := BuildTool(t, "fs_listdir")
+	if runtime.GOOS == "windows" {
+		if !strings.HasSuffix(path, ".exe") {
+			t.Fatalf("expected .exe suffix on Windows, got %q", path)
+		}
+	} else {
+		if strings.HasSuffix(path, ".exe") {
+			t.Fatalf("did not expect .exe suffix on non-Windows, got %q", path)
+		}
+	}
+}

--- a/tools/testutil/tempdir.go
+++ b/tools/testutil/tempdir.go
@@ -1,0 +1,25 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// MakeRepoRelTempDir creates a temporary directory under the current
+// package working directory and returns its relative path (basename).
+// The directory is removed at test cleanup.
+func MakeRepoRelTempDir(t *testing.T, prefix string) string {
+	t.Helper()
+	tmpAbs, err := os.MkdirTemp(".", prefix)
+	if err != nil {
+		t.Fatalf("mkdir temp under repo: %v", err)
+	}
+	base := filepath.Base(tmpAbs)
+	t.Cleanup(func() {
+		if err := os.RemoveAll(base); err != nil {
+			t.Logf("cleanup remove %s: %v", base, err)
+		}
+	})
+	return base
+}


### PR DESCRIPTION
## Summary
Adds example tool get_time with tests, wires tools/bin build via Makefile, and introduces tools.json.

## Scope
- tools/cmd/get_time/*
- tools/testutil/* (helper for building tools in tests)
- tools.json
- Makefile (build-tools for tools/bin)
- README.md quickstart references

## Risks
Low. Standalone tool, no impact on existing code.

## Test plan
- make build-tool NAME=get_time
- ./tools/bin/get_time <<< '{"tz":"Europe/Helsinki"}'

## Tracking
See FEATURE_CHECKLIST.md line for PR #10 and corresponding CHANGELOG.md entry.