### PR TITLE
Tool: fs_stat

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -1,0 +1,517 @@
+{
+  "tools": [
+    {
+      "name": "get_time",
+      "description": "Get current time for an IANA timezone",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone, e.g. Europe/Helsinki"
+          },
+          "tz": {
+            "type": "string",
+            "description": "Alias for timezone (deprecated)"
+          }
+        },
+        "required": ["timezone"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/get_time"],
+      "timeoutSec": 5
+    }
+    ,
+    {
+      "name": "http_fetch",
+      "description": "Safe HTTP/HTTPS fetcher with byte cap and redirects",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "url": {"type": "string"},
+          "method": {"type": "string", "enum": ["GET", "HEAD"]},
+          "max_bytes": {"type": "integer", "minimum": 1, "default": 1048576},
+          "timeout_ms": {"type": "integer", "minimum": 1, "default": 10000},
+          "decompress": {"type": "boolean", "default": true}
+        },
+        "required": ["url"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/http_fetch"],
+      "timeoutSec": 15,
+      "envPassthrough": ["HTTP_TIMEOUT_MS"]
+    }
+    ,
+    {
+      "name": "fs_read_file",
+      "description": "Read a repository-relative file as base64 with optional offset and max bytes",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string", "description": "Repo-relative path to file"},
+          "offsetBytes": {"type": "integer", "minimum": 0},
+          "maxBytes": {"type": "integer", "minimum": 1}
+        },
+        "required": ["path"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_read_file"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_write_file",
+      "description": "Atomically write a repository-relative file from base64 content",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "contentBase64": {"type": "string"},
+          "createModeOctal": {"type": "string"}
+        },
+        "required": ["path", "contentBase64"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_write_file"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_append_file",
+      "description": "Append base64 content to a repository-relative file (create if missing)",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "contentBase64": {"type": "string"}
+        },
+        "required": ["path", "contentBase64"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_append_file"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_mkdirp",
+      "description": "Recursively create a directory path",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "modeOctal": {"type": "string"}
+        },
+        "required": ["path"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_mkdirp"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_rm",
+      "description": "Remove a repository-relative file or directory",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "recursive": {"type": "boolean"},
+          "force": {"type": "boolean"}
+        },
+        "required": ["path"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_rm"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_move",
+      "description": "Move or rename a repository-relative path",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "from": {"type": "string"},
+          "to": {"type": "string"},
+          "overwrite": {"type": "boolean"}
+        },
+        "required": ["from", "to"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_move"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_search",
+      "description": "Search repository files for a query with optional regex/globs",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "query": {"type": "string"},
+          "regex": {"type": "boolean"},
+          "globs": {"type": "array", "items": {"type": "string"}},
+          "maxResults": {"type": "integer", "minimum": 1}
+        },
+        "required": ["query"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_search"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_listdir",
+      "description": "List directory entries with optional recursion and glob filtering",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "recursive": {"type": "boolean"},
+          "globs": {"type": "array", "items": {"type": "string"}},
+          "includeHidden": {"type": "boolean"},
+          "maxResults": {"type": "integer", "minimum": 1}
+        },
+        "required": ["path"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_listdir"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_read_lines",
+      "description": "Read a line range from a repository-relative file with optional byte cap",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "startLine": {"type": "integer", "minimum": 0},
+          "endLine": {"type": "integer", "minimum": 0},
+          "maxBytes": {"type": "integer", "minimum": 1}
+        },
+        "required": ["path", "startLine", "endLine"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_read_lines"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "fs_apply_patch",
+      "description": "Apply a strict unified diff (optional dry-run)",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "unifiedDiff": {"type": "string"},
+          "dryRun": {"type": "boolean"}
+        },
+        "required": ["unifiedDiff"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_apply_patch"],
+      "timeoutSec": 10
+    },
+    {
+      "name": "fs_edit_range",
+      "description": "Atomically replace a byte range in a file with base64 content",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "startByte": {"type": "integer", "minimum": 0},
+          "endByte": {"type": "integer", "minimum": 0},
+          "replacementBase64": {"type": "string"},
+          "expectedSha256": {"type": "string"}
+        },
+        "required": ["path", "startByte", "endByte", "replacementBase64"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_edit_range"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "exec",
+      "description": "Run an arbitrary program with args, cwd, env, and stdin",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "cmd": {"type": "string"},
+          "args": {"type": "array", "items": {"type": "string"}},
+          "cwd": {"type": "string"},
+          "env": {"type": "object", "additionalProperties": {"type": "string"}},
+          "stdin": {"type": "string"},
+          "timeoutSec": {"type": "integer", "minimum": 1}
+        },
+        "required": ["cmd"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/exec"],
+      "timeoutSec": 30
+    },
+    {
+      "name": "fs_stat",
+      "description": "Stat a path (optionally follow symlinks and compute hash)",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "path": {"type": "string"},
+          "followSymlinks": {"type": "boolean"},
+          "hash": {"type": "string", "enum": ["none", "sha256"]}
+        },
+        "required": ["path"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/fs_stat"],
+      "timeoutSec": 5
+    },
+    {
+      "name": "img_create",
+      "description": "Generate image(s) with OpenAI Images API and save to repo or return base64",
+      "schema": {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+          "prompt": {"type": "string"},
+          "n": {"type": "integer", "minimum": 1, "maximum": 4, "default": 1},
+          "size": {"type": "string", "pattern": "^\\d{3,4}x\\d{3,4}$", "default": "1024x1024"},
+          "model": {"type": "string", "default": "gpt-image-1"},
+          "return_b64": {"type": "boolean", "default": false},
+          "save": {
+            "type": "object",
+            "required": ["dir"],
+            "properties": {
+              "dir": {"type": "string"},
+              "basename": {"type": "string", "default": "img"},
+              "ext": {"type": "string", "enum": ["png"], "default": "png"}
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/img_create"],
+      "timeoutSec": 120,
+      "envPassthrough": ["OAI_API_KEY", "OAI_BASE_URL", "OAI_IMAGE_BASE_URL", "OAI_HTTP_TIMEOUT"]
+    },
+    {
+      "name": "searxng_search",
+      "description": "Meta search via SearXNG",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "q": {"type": "string"},
+          "time_range": {"type": "string", "enum": ["day","week","month","year"]},
+          "categories": {"type": "array", "items": {"type": "string"}},
+          "engines": {"type": "array", "items": {"type": "string"}},
+          "language": {"type": "string"},
+          "page": {"type": "integer", "minimum": 1},
+          "size": {"type": "integer", "minimum": 1, "maximum": 50}
+        },
+        "required": ["q"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/searxng_search"],
+      "timeoutSec": 15,
+      "envPassthrough": ["SEARXNG_BASE_URL","HTTP_TIMEOUT_MS"]
+    }
+    ,
+    {
+      "name": "robots_check",
+      "description": "Evaluate robots.txt for a given URL and user agent",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "url": {"type": "string"},
+          "user_agent": {"type": "string"}
+        },
+        "required": ["url"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/robots_check"],
+      "timeoutSec": 10
+    }
+    ,
+    {
+      "name": "readability_extract",
+      "description": "Extract article content from HTML using go-readability",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "html": {"type": "string"},
+          "base_url": {"type": "string"}
+        },
+        "required": ["html", "base_url"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/readability_extract"],
+      "timeoutSec": 10
+    }
+    ,
+    {
+      "name": "metadata_extract",
+      "description": "Extract OpenGraph, Twitter cards, and JSON-LD from HTML",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "html": {"type": "string"},
+          "base_url": {"type": "string"}
+        },
+        "required": ["html", "base_url"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/metadata_extract"],
+      "timeoutSec": 10
+    }
+    ,
+    {
+      "name": "pdf_extract",
+      "description": "Extract text from PDF pages; optional OCR via tesseract",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "pdf_base64": {"type": "string"},
+          "pages": {"type": "array", "items": {"type": "integer"}}
+        },
+        "required": ["pdf_base64"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/pdf_extract"],
+      "timeoutSec": 60,
+      "envPassthrough": ["ENABLE_OCR"]
+    }
+    ,
+    {
+      "name": "rss_fetch",
+      "description": "Fetch and parse RSS/Atom feeds with conditional GET",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "url": {"type": "string"},
+          "if_modified_since": {"type": "string"}
+        },
+        "required": ["url"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/rss_fetch"],
+      "timeoutSec": 10
+    }
+    ,
+    {
+      "name": "wayback_lookup",
+      "description": "Query Internet Archive Wayback Machine for closest snapshot; optionally trigger save",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "url": {"type": "string"},
+          "save": {"type": "boolean", "default": false}
+        },
+        "required": ["url"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/wayback_lookup"],
+      "timeoutSec": 10
+    }
+    ,
+    {
+      "name": "wiki_query",
+      "description": "MediaWiki summaries/search",
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "titles": {
+            "type": "string",
+            "description": "Exact page title to fetch summary for (mutually exclusive with 'search')"
+          },
+          "search": {
+            "type": "string",
+            "description": "Full-text search term to find pages (mutually exclusive with 'titles')"
+          },
+          "language": {
+            "type": "string",
+            "default": "en",
+            "description": "MediaWiki language code, e.g. en, fi"
+          }
+        }
+      },
+      "command": ["./tools/bin/wiki_query"],
+      "timeoutSec": 10
+    }
+    ,
+    {
+      "name": "openalex_search",
+      "description": "Search scholarly works via OpenAlex",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "q": {"type": "string"},
+          "from": {"type": "string"},
+          "to": {"type": "string"},
+          "per_page": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10}
+        },
+        "required": ["q"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/openalex_search"],
+      "timeoutSec": 15
+    }
+    ,
+    {
+      "name": "crossref_search",
+      "description": "Search DOI metadata via Crossref",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "q": {"type": "string"},
+          "rows": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10}
+        },
+        "required": ["q"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/crossref_search"],
+      "timeoutSec": 15,
+      "envPassthrough": ["CROSSREF_MAILTO", "HTTP_TIMEOUT_MS"]
+    }
+    ,
+    {
+      "name": "github_search",
+      "description": "Search GitHub repositories, code, issues, or commits",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "q": {"type": "string"},
+          "type": {"type": "string", "enum": ["repositories", "code", "issues", "commits"]},
+          "per_page": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10}
+        },
+        "required": ["q", "type"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/github_search"],
+      "timeoutSec": 15,
+      "envPassthrough": ["GITHUB_TOKEN"]
+    }
+    ,
+    {
+      "name": "citation_pack",
+      "description": "Normalize a citation and optionally include Wayback archive URL",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "doc": {
+            "type": "object",
+            "properties": {
+              "title": {"type": "string"},
+              "url": {"type": "string"},
+              "published_at": {"type": "string"}
+            },
+            "required": ["url"],
+            "additionalProperties": false
+          },
+          "archive": {
+            "type": "object",
+            "properties": {
+              "wayback": {"type": "boolean"}
+            },
+            "additionalProperties": false
+          }
+        },
+        "required": ["doc"],
+        "additionalProperties": false
+      },
+      "command": ["./tools/bin/citation_pack"],
+      "timeoutSec": 10
+    }
+  ]
+}

--- a/tools/cmd/fs_stat/fs_stat.go
+++ b/tools/cmd/fs_stat/fs_stat.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type statInput struct {
+	Path           string `json:"path"`
+	FollowSymlinks bool   `json:"followSymlinks,omitempty"`
+	Hash           string `json:"hash,omitempty"`
+}
+
+type statOutput struct {
+	Exists    bool   `json:"exists"`
+	Type      string `json:"type"`
+	SizeBytes int64  `json:"sizeBytes"`
+	ModeOctal string `json:"modeOctal"`
+	ModTime   string `json:"modTime"`
+	Sha256    string `json:"sha256,omitempty"`
+}
+
+func main() {
+	in, err := readInput(os.Stdin)
+	if err != nil {
+		stderrJSON(err)
+		os.Exit(1)
+	}
+	if err := validatePath(in.Path); err != nil {
+		stderrJSON(err)
+		os.Exit(1)
+	}
+	out, err := statPath(in)
+	if err != nil {
+		stderrJSON(err)
+		os.Exit(1)
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+		stderrJSON(fmt.Errorf("encode json: %w", err))
+		os.Exit(1)
+	}
+}
+
+func readInput(r io.Reader) (statInput, error) {
+	var in statInput
+	b, err := io.ReadAll(bufio.NewReader(r))
+	if err != nil {
+		return in, fmt.Errorf("read stdin: %w", err)
+	}
+	if err := json.Unmarshal(b, &in); err != nil {
+		return in, fmt.Errorf("parse json: %w", err)
+	}
+	if strings.TrimSpace(in.Path) == "" {
+		return in, fmt.Errorf("path is required")
+	}
+	return in, nil
+}
+
+func validatePath(p string) error {
+	if filepath.IsAbs(p) {
+		return fmt.Errorf("ABSOLUTE_PATH: %s", p)
+	}
+	clean := filepath.ToSlash(filepath.Clean(p))
+	if strings.HasPrefix(clean, "../") || strings.Contains(clean, "/../") {
+		return fmt.Errorf("PATH_ESCAPE: %s", p)
+	}
+	return nil
+}
+
+func statPath(in statInput) (statOutput, error) {
+	var out statOutput
+	var fi os.FileInfo
+	var err error
+	if in.FollowSymlinks {
+		fi, err = os.Stat(in.Path)
+	} else {
+		fi, err = os.Lstat(in.Path)
+	}
+	if err != nil {
+		if os.IsNotExist(err) {
+			return statOutput{Exists: false}, nil
+		}
+		return statOutput{}, err
+	}
+	mode := fi.Mode()
+	typeStr := "other"
+	if mode.IsRegular() {
+		typeStr = "file"
+	} else if mode.IsDir() {
+		typeStr = "dir"
+	} else if mode&os.ModeSymlink != 0 {
+		typeStr = "symlink"
+	}
+	out = statOutput{
+		Exists:    true,
+		Type:      typeStr,
+		SizeBytes: fi.Size(),
+		ModeOctal: fmt.Sprintf("%04o", mode.Perm()),
+		ModTime:   fi.ModTime().UTC().Format("2006-01-02T15:04:05Z07:00"),
+	}
+	if in.Hash == "sha256" && typeStr == "file" {
+		data, err := os.ReadFile(in.Path)
+		if err == nil {
+			h := sha256.Sum256(data)
+			out.Sha256 = hex.EncodeToString(h[:])
+		}
+	}
+	return out, nil
+}
+
+func stderrJSON(err error) {
+	msg := err.Error()
+	msg = strings.ReplaceAll(msg, "\n", " ")
+	fmt.Fprintf(os.Stderr, "{\"error\":%q}\n", msg)
+}

--- a/tools/cmd/fs_stat/fs_stat_test.go
+++ b/tools/cmd/fs_stat/fs_stat_test.go
@@ -1,0 +1,235 @@
+package main
+
+// https://github.com/hyperifyio/goagent/issues/1
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hyperifyio/goagent/tools/testutil"
+)
+
+type fsStatOutput struct {
+	Exists    bool   `json:"exists"`
+	Type      string `json:"type"`
+	SizeBytes int64  `json:"sizeBytes"`
+	ModeOctal string `json:"modeOctal"`
+	ModTime   string `json:"modTime"`
+	SHA256    string `json:"sha256,omitempty"`
+}
+
+// build via tools/testutil.BuildTool after migration to tools/cmd/fs_stat
+
+// runFsStat runs the built fs_stat tool with the given JSON input and decodes stdout.
+func runFsStat(t *testing.T, bin string, input any) (fsStatOutput, string, int) {
+	t.Helper()
+	data, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("marshal input: %v", err)
+	}
+	cmd := exec.Command(bin)
+	cmd.Dir = "."
+	cmd.Stdin = bytes.NewReader(data)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	code := 0
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			code = ee.ExitCode()
+		} else {
+			code = 1
+		}
+	}
+	var out fsStatOutput
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &out); err != nil {
+		t.Fatalf("unmarshal stdout: %v; raw=%q", err, stdout.String())
+	}
+	return out, stderr.String(), code
+}
+
+// makeRepoRelTempFile creates a temporary file under the repository root and
+// returns its repo-relative path. The file is cleaned up automatically.
+func makeRepoRelTempFile(t *testing.T, dirPrefix string, data []byte) (relPath string) {
+	t.Helper()
+	tmpAbs, err := os.MkdirTemp(".", dirPrefix)
+	if err != nil {
+		t.Fatalf("mkdir temp under repo: %v", err)
+	}
+	base := filepath.Base(tmpAbs)
+	fileRel := filepath.Join(base, "file.bin")
+	if err := os.WriteFile(fileRel, data, 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(base); err != nil {
+			t.Logf("cleanup remove %s: %v", base, err)
+		}
+	})
+	return fileRel
+}
+
+// TestFsStat_File expresses the minimal contract: for an existing regular file,
+// the tool exits 0 and reports exists=true, type="file", and sizeBytes.
+func TestFsStat_File(t *testing.T) {
+	bin := testutil.BuildTool(t, "fs_stat")
+
+	content := []byte("hello-fsstat")
+	path := makeRepoRelTempFile(t, "fsstat-file-", content)
+
+	out, stderr, code := runFsStat(t, bin, map[string]any{
+		"path": path,
+	})
+	if code != 0 {
+		t.Fatalf("expected success, got exit=%d stderr=%q", code, stderr)
+	}
+	if !out.Exists {
+		t.Fatalf("expected exists=true, got false")
+	}
+	if out.Type != "file" {
+		t.Fatalf("expected type=file, got %q", out.Type)
+	}
+	if out.SizeBytes != int64(len(content)) {
+		t.Fatalf("sizeBytes mismatch: got %d want %d", out.SizeBytes, len(content))
+	}
+}
+
+// TestFsStat_MissingPath verifies that a non-existent path is handled
+// gracefully: exit code 0 and exists=false in the JSON output.
+func TestFsStat_MissingPath(t *testing.T) {
+	bin := testutil.BuildTool(t, "fs_stat")
+
+	// Use a path name that is very unlikely to exist under repo root.
+	missing := filepath.Join("fsstat-missing-", "no-such-file.bin")
+
+	out, stderr, code := runFsStat(t, bin, map[string]any{
+		"path": missing,
+	})
+	if code != 0 {
+		t.Fatalf("expected success (exit 0) for missing path, got exit=%d stderr=%q", code, stderr)
+	}
+	if out.Exists {
+		t.Fatalf("expected exists=false for missing path")
+	}
+}
+
+// TestFsStat_Symlink_NoFollow verifies that when followSymlinks=false, a symlink
+// is reported with type="symlink" (not the target type).
+func TestFsStat_Symlink_NoFollow(t *testing.T) {
+	bin := testutil.BuildTool(t, "fs_stat")
+
+	content := []byte("hello-symlink")
+	target := makeRepoRelTempFile(t, "fsstat-symlink-target-", content)
+
+	// Create a symlink alongside the target within repo root.
+	link := target + ".lnk"
+	// Use a relative target name so resolution is relative to link's directory.
+	if err := os.Symlink(filepath.Base(target), link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Remove(link); err != nil {
+			t.Logf("cleanup remove %s: %v", link, err)
+		}
+	})
+
+	out, stderr, code := runFsStat(t, bin, map[string]any{
+		"path":           link,
+		"followSymlinks": false,
+	})
+	if code != 0 {
+		t.Fatalf("expected success, got exit=%d stderr=%q", code, stderr)
+	}
+	if !out.Exists {
+		t.Fatalf("expected exists=true, got false")
+	}
+	if out.Type != "symlink" {
+		t.Fatalf("expected type=symlink when not following, got %q", out.Type)
+	}
+}
+
+// TestFsStat_Symlink_Follow verifies that when followSymlinks=true, a symlink to
+// a regular file reports the target type and size.
+func TestFsStat_Symlink_Follow(t *testing.T) {
+	bin := testutil.BuildTool(t, "fs_stat")
+
+	content := []byte("hello-symlink-follow")
+	target := makeRepoRelTempFile(t, "fsstat-symlink-follow-", content)
+	link := target + ".lnk"
+	if err := os.Symlink(filepath.Base(target), link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Remove(link); err != nil {
+			t.Logf("cleanup remove %s: %v", link, err)
+		}
+	})
+
+	out, stderr, code := runFsStat(t, bin, map[string]any{
+		"path":           link,
+		"followSymlinks": true,
+	})
+	if code != 0 {
+		t.Fatalf("expected success, got exit=%d stderr=%q", code, stderr)
+	}
+	if !out.Exists {
+		t.Fatalf("expected exists=true, got false")
+	}
+	if out.Type != "file" {
+		t.Fatalf("expected type=file when following, got %q", out.Type)
+	}
+	if out.SizeBytes != int64(len(content)) {
+		t.Fatalf("sizeBytes mismatch: got %d want %d", out.SizeBytes, len(content))
+	}
+}
+
+// TestFsStat_SHA256 verifies that when hash="sha256" and the path is a regular
+// file, the tool includes the SHA256 hex digest in the output.
+func TestFsStat_SHA256(t *testing.T) {
+	bin := testutil.BuildTool(t, "fs_stat")
+
+	content := []byte("sha256-content\n")
+	path := makeRepoRelTempFile(t, "fsstat-sha256-", content)
+
+	out, stderr, code := runFsStat(t, bin, map[string]any{
+		"path": path,
+		"hash": "sha256",
+	})
+	if code != 0 {
+		t.Fatalf("expected success, got exit=%d stderr=%q", code, stderr)
+	}
+	if out.SHA256 == "" {
+		t.Fatalf("expected sha256 present")
+	}
+}
+
+// TestFsStat_ErrorJSONContract verifies standardized error contract: on failure,
+// the tool writes a single-line JSON object with an "error" key to stderr and
+// exits non-zero (umbrella L177).
+func TestFsStat_ErrorJSONContract(t *testing.T) {
+	bin := testutil.BuildTool(t, "fs_stat")
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(bin)
+	cmd.Dir = "."
+	cmd.Stdin = bytes.NewReader([]byte(`{}`))
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("expected non-zero exit for invalid input; stderr=%q", stderr.String())
+	}
+	line := strings.TrimSpace(stderr.String())
+	var obj map[string]any
+	if jerr := json.Unmarshal([]byte(line), &obj); jerr != nil {
+		t.Fatalf("stderr is not JSON: %q err=%v", line, jerr)
+	}
+	if _, ok := obj["error"]; !ok {
+		t.Fatalf("stderr JSON missing 'error' key: %v", obj)
+	}
+}


### PR DESCRIPTION
## Summary
Add fs_stat tool (stat path, optional hash) with tests; declare in tools.json.

## Scope
- tools/cmd/fs_stat/**
- tools.json (entry)

## Notes
- Opened as an independent slice from main to keep diffs minimal.
- Tests depend on shared testutil present in another open PR; marking draft until prerequisites land.

Refs FEATURE_CHECKLIST.md per-tool slicing line.