### PR TITLE
Tool: img_create

### DIFF
--- a/docs/reference/img_create.md
+++ b/docs/reference/img_create.md
@@ -1,0 +1,136 @@
+# Image generation tool (img_create)
+
+See ADR‑0006 for design rationale and links: [../adr/0006-image-generation-tool-img_create.md](../adr/0006-image-generation-tool-img_create.md)
+
+Generate image(s) via an OpenAI‑compatible Images API and either save PNG files into your repository (default) or return base64 on demand. This tool is invoked by the agent as a function tool using JSON over stdin/stdout with strict timeouts and no shell.
+
+## Contracts
+
+- Stdin: single JSON object matching the parameters below
+- Stdout (success): single‑line JSON result
+- Stderr (failure): single‑line JSON object `{ "error": "...", "hint?": "..." }`, non‑zero exit
+
+### Example: save files (default)
+
+Input to stdin:
+
+```json
+{
+  "prompt": "tiny-pixel",
+  "n": 1,
+  "size": "1024x1024",
+  "save": {"dir": "assets", "basename": "img", "ext": "png"}
+}
+```
+
+Output on stdout (shape shown; paths and hashes will vary):
+
+```json
+{
+  "saved": [
+    {"path": "assets/img_001.png", "bytes": 95, "sha256": "<hex>"}
+  ],
+  "n": 1,
+  "size": "1024x1024",
+  "model": "gpt-image-1"
+}
+```
+
+### Example: return base64 instead of saving
+
+Input to stdin:
+
+```json
+{
+  "prompt": "tiny-pixel",
+  "n": 1,
+  "return_b64": true
+}
+```
+
+Output on stdout by default elides base64 for transcript hygiene:
+
+```json
+{
+  "images": [
+    {"b64": "", "hint": "b64 elided"}
+  ]
+}
+```
+
+Set `IMG_CREATE_DEBUG_B64=1` (or `DEBUG_B64=1`) to include base64 in stdout for debugging.
+
+## Parameters
+
+| Name        | Type      | Required | Default       | Constraints                               | Notes |
+|-------------|-----------|----------|---------------|-------------------------------------------|-------|
+| `prompt`    | string    | yes      | —             | non‑empty                                  | Text prompt for the image(s).
+| `n`         | integer   | no       | 1             | 1 ≤ n ≤ 4                                  | Number of images to generate.
+| `size`      | string    | no       | `1024x1024`   | regex `^\d{3,4}x\d{3,4}$`                 | Width x height in pixels.
+| `model`     | string    | no       | `gpt-image-1` | —                                         | Passed as‑is to the Images API.
+| `return_b64`| boolean   | no       | false         | —                                         | When true, returns base64 JSON instead of writing files.
+| `save.dir`  | string    | cond.    | —             | repo‑relative; must not escape repo root   | Required when `return_b64=false` (default).
+| `save.basename` | string| no       | `img`         | must not contain path separators           | Filename stem; tool appends `_<001..>.ext`.
+| `save.ext`  | string    | no       | `png`         | enum: `png`                                | Output format; currently PNG only.
+| `extras`    | object    | no       | —             | shallow map of string→primitive            | Optional pass-through for known keys like `background:"transparent"`; only primitives are allowed; core keys are not overridden.
+
+Notes:
+- When saving files, the tool writes atomically to `save.dir` and returns file metadata including SHA‑256.
+- Filenames are generated as `<basename>_NNN.<ext>` with zero‑padded indices starting at 001.
+
+## HTTP behavior
+
+- Endpoint: `POST ${OAI_IMAGE_BASE_URL:-$OAI_BASE_URL}/v1/images/generations`
+- Request body:
+  - `{ "model", "prompt", "n", "size", "response_format": "b64_json" }`
+- Headers:
+  - `Content-Type: application/json`
+  - `Authorization: Bearer $OAI_API_KEY` (if present)
+- Timeout: from `OAI_HTTP_TIMEOUT` (duration, default 120s)
+- Retries: up to 2 retries (3 total attempts) on timeouts, HTTP 429, and 5xx with backoff `250ms, 500ms, 1s`
+- Error mapping: non‑2xx responses attempt to extract a useful message from `{error}` or `{error:{message}}`; otherwise emit `api status <code>`
+
+## Environment
+
+- `OAI_IMAGE_BASE_URL`: Base URL for Images API (preferred)
+- `OAI_BASE_URL`: Fallback base URL when `OAI_IMAGE_BASE_URL` is unset
+- `OAI_API_KEY`: API key for authorization (optional for mocks)
+- `OAI_HTTP_TIMEOUT`: HTTP timeout (e.g., `90s`)
+- `IMG_CREATE_DEBUG_B64` / `DEBUG_B64`: When set truthy, include base64 in stdout for `return_b64=true`
+
+The manifest allowlist passes through only the following variables to the tool:
+
+```json
+["OAI_API_KEY", "OAI_BASE_URL", "OAI_IMAGE_BASE_URL", "OAI_HTTP_TIMEOUT"]
+```
+
+## Underlying API (cURL)
+
+For transparency, the tool issues the equivalent of:
+
+```bash
+curl -sS -X POST "$OAI_BASE_URL/v1/images/generations" \
+  -H "Authorization: Bearer $OAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-image-1",
+    "prompt": "tiny-pixel",
+    "n": 1,
+    "size": "1024x1024",
+    "response_format": "b64_json"
+  }'
+```
+
+When `OAI_IMAGE_BASE_URL` is set, it is used instead of `OAI_BASE_URL`.
+
+## Safety notes
+
+- Strict repository‑relative writes: `save.dir` must be within the repository; absolute paths and `..` escapes are rejected.
+- No shell execution: the tool is executed via argv only; stdin/stdout are JSON.
+- Transcript hygiene: by default, base64 is elided from stdout to prevent large transcripts. Enable debug envs to view base64 locally.
+
+## Related documentation
+
+- Images & vision guide: [OpenAI Images docs](https://platform.openai.com/docs/guides/images)
+- Model reference: [OpenAI model catalog (gpt-image-1)](https://platform.openai.com/docs/models)
+- Tools manifest reference: see `docs/reference/tools-manifest.md`

--- a/tools/cmd/img_create/img_create.go
+++ b/tools/cmd/img_create/img_create.go
@@ -1,0 +1,388 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type inputSpec struct {
+	Prompt    string `json:"prompt"`
+	N         int    `json:"n"`
+	Size      string `json:"size"`
+	Model     string `json:"model"`
+	ReturnB64 bool   `json:"return_b64"`
+	// Optional extras that are shallow-merged into the request body
+	// after validation as string->primitive. Unknown or non-primitive
+	// values are dropped. Core keys (model, prompt, n, size, response_format)
+	// are never overridden by extras.
+	Extras map[string]any `json:"extras"`
+	Save   *struct {
+		Dir      string `json:"dir"`
+		Basename string `json:"basename"`
+		Ext      string `json:"ext"`
+	} `json:"save"`
+}
+
+var sizeRe = regexp.MustCompile(`^\d{3,4}x\d{3,4}$`)
+
+func main() {
+	if err := run(); err != nil {
+		msg := strings.TrimSpace(err.Error())
+		// Best-effort error reporting to stderr in JSON; ignore encode errors
+		// nolint below: best-effort reporting; failures are non-fatal as we exit non-zero
+		_ = json.NewEncoder(os.Stderr).Encode(map[string]string{"error": msg}) //nolint:errcheck
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	// Parse and validate input
+	in, err := parseInput(os.Stdin)
+	if err != nil {
+		return err
+	}
+	// Build request body
+	bodyBytes, err := buildRequestBody(in)
+	if err != nil {
+		return err
+	}
+	// Perform HTTP request with limited retries
+	respBody, model, err := doRequest(bodyBytes)
+	if err != nil {
+		return err
+	}
+	// Format output (either save files or return b64)
+	return produceOutput(in, respBody, model)
+}
+
+// parseInput reads JSON from r and returns a validated inputSpec.
+func parseInput(r io.Reader) (inputSpec, error) {
+	var in inputSpec
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return in, fmt.Errorf("read stdin: %w", err)
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return in, errors.New("missing json input")
+	}
+	if err := json.Unmarshal(data, &in); err != nil {
+		return in, fmt.Errorf("bad json: %w", err)
+	}
+	if strings.TrimSpace(in.Prompt) == "" {
+		return in, errors.New("prompt is required")
+	}
+	if in.N == 0 {
+		in.N = 1
+	}
+	if in.N < 1 || in.N > 4 {
+		return in, errors.New("n must be between 1 and 4")
+	}
+	if in.Size == "" {
+		in.Size = "1024x1024"
+	}
+	if !sizeRe.MatchString(in.Size) {
+		return in, errors.New("size must match ^\\d{3,4}x\\d{3,4}$")
+	}
+	if in.Model == "" {
+		in.Model = "gpt-image-1"
+	}
+	if !in.ReturnB64 {
+		if in.Save == nil || strings.TrimSpace(in.Save.Dir) == "" {
+			return in, errors.New("save.dir is required when return_b64=false")
+		}
+		if filepath.IsAbs(in.Save.Dir) {
+			return in, errors.New("save.dir must be repo-relative")
+		}
+		clean := filepath.Clean(in.Save.Dir)
+		if strings.HasPrefix(clean, "..") {
+			return in, errors.New("save.dir escapes repository root")
+		}
+		if in.Save.Basename == "" {
+			in.Save.Basename = "img"
+		}
+		if in.Save.Ext == "" {
+			in.Save.Ext = "png"
+		}
+		if in.Save.Ext != "png" {
+			return in, errors.New("ext must be 'png'")
+		}
+	}
+	return in, nil
+}
+
+// buildRequestBody creates the JSON body for the Images API.
+func buildRequestBody(in inputSpec) ([]byte, error) {
+	reqBody := map[string]any{
+		"model":           in.Model,
+		"prompt":          in.Prompt,
+		"n":               in.N,
+		"size":            in.Size,
+		"response_format": "b64_json",
+	}
+	if len(in.Extras) > 0 {
+		safe := sanitizeExtras(in.Extras)
+		for k, v := range safe {
+			switch k {
+			case "model", "prompt", "n", "size", "response_format":
+			default:
+				reqBody[k] = v
+			}
+		}
+	}
+	b, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	return b, nil
+}
+
+// doRequest posts to the Images API with retries and returns body and model.
+func doRequest(bodyBytes []byte) ([]byte, string, error) {
+	baseURL := strings.TrimRight(firstNonEmpty(os.Getenv("OAI_IMAGE_BASE_URL"), os.Getenv("OAI_BASE_URL"), ""), "/")
+	if baseURL == "" {
+		return nil, "", errors.New("missing OAI_IMAGE_BASE_URL or OAI_BASE_URL")
+	}
+	url := baseURL + "/v1/images/generations"
+	client := &http.Client{Timeout: httpTimeout()}
+	var lastErr error
+	var resp *http.Response
+	for attempt := 0; attempt < 3; attempt++ {
+		req, err := http.NewRequest("POST", url, bytes.NewReader(bodyBytes))
+		if err != nil {
+			return nil, "", fmt.Errorf("new request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if key := strings.TrimSpace(os.Getenv("OAI_API_KEY")); key != "" {
+			req.Header.Set("Authorization", "Bearer "+key)
+		}
+		resp, err = client.Do(req)
+		if err != nil {
+			lastErr = err
+		} else {
+			// For retry-able statuses, drain and retry
+			if shouldRetryStatus(resp.StatusCode) && attempt < 2 {
+				_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck
+				_ = resp.Body.Close()                 //nolint:errcheck
+				time.Sleep(backoffDelay(attempt))
+				continue
+			}
+			break
+		}
+		if attempt < 2 {
+			time.Sleep(backoffDelay(attempt))
+		}
+	}
+	if resp == nil {
+		return nil, "", fmt.Errorf("http error: %v", lastErr)
+	}
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var obj map[string]any
+		if json.Unmarshal(body, &obj) == nil {
+			if msg, ok := obj["error"].(string); ok && msg != "" {
+				return nil, "", errors.New(msg)
+			}
+			if errobj, ok := obj["error"].(map[string]any); ok {
+				if m, ok2 := errobj["message"].(string); ok2 && m != "" {
+					return nil, "", errors.New(m)
+				}
+			}
+		}
+		return nil, "", fmt.Errorf("api status %d", resp.StatusCode)
+	}
+	// Success
+	return body, resp.Header.Get("OpenAI-Model"), nil
+}
+
+// produceOutput formats and writes output based on inputSpec.
+func produceOutput(in inputSpec, body []byte, model string) error {
+	var apiResp struct {
+		Data []struct {
+			B64 string `json:"b64_json"`
+		} `json:"data"`
+		Model string `json:"model,omitempty"`
+	}
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	if len(apiResp.Data) == 0 {
+		return errors.New("no images returned")
+	}
+	_ = model // reserved for future use; apiResp.Model may already include it
+
+	if in.ReturnB64 {
+		debug := isTruthyEnv("IMG_CREATE_DEBUG_B64") || isTruthyEnv("DEBUG_B64")
+		type img struct {
+			B64  string `json:"b64"`
+			Hint string `json:"hint,omitempty"`
+		}
+		out := struct {
+			Images []img `json:"images"`
+		}{Images: make([]img, 0, len(apiResp.Data))}
+		for _, d := range apiResp.Data {
+			if debug {
+				out.Images = append(out.Images, img{B64: d.B64})
+			} else {
+				out.Images = append(out.Images, img{B64: "", Hint: "b64 elided"})
+			}
+		}
+		return writeJSON(out)
+	}
+
+	// Save to disk
+	dir := filepath.Clean(in.Save.Dir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	if strings.Contains(in.Save.Basename, "/") || strings.Contains(in.Save.Basename, string(filepath.Separator)) {
+		return errors.New("basename must not contain path separators")
+	}
+	saved := make([]struct {
+		Path   string `json:"path"`
+		Bytes  int    `json:"bytes"`
+		Sha256 string `json:"sha256"`
+	}, 0, len(apiResp.Data))
+	for i, d := range apiResp.Data {
+		imgBytes, decErr := decodeStdB64(d.B64)
+		if decErr != nil {
+			return fmt.Errorf("decode b64 image %d: %w", i+1, decErr)
+		}
+		fname := fmt.Sprintf("%s_%03d.%s", in.Save.Basename, i+1, in.Save.Ext)
+		finalPath := filepath.Join(dir, fname)
+		tmpPath := filepath.Join(dir, ".tmp-"+fname+"-"+strconv.FormatInt(time.Now().UnixNano(), 10))
+		if err := os.WriteFile(tmpPath, imgBytes, 0o644); err != nil {
+			return fmt.Errorf("write temp file: %w", err)
+		}
+		if err := os.Rename(tmpPath, finalPath); err != nil {
+			_ = os.Remove(tmpPath) //nolint:errcheck
+			return fmt.Errorf("rename: %w", err)
+		}
+		sum := sha256.Sum256(imgBytes)
+		saved = append(saved, struct {
+			Path   string `json:"path"`
+			Bytes  int    `json:"bytes"`
+			Sha256 string `json:"sha256"`
+		}{Path: finalPath, Bytes: len(imgBytes), Sha256: hex.EncodeToString(sum[:])})
+	}
+	out := struct {
+		Saved []struct {
+			Path   string `json:"path"`
+			Bytes  int    `json:"bytes"`
+			Sha256 string `json:"sha256"`
+		} `json:"saved"`
+		N     int    `json:"n"`
+		Size  string `json:"size"`
+		Model string `json:"model"`
+	}{Saved: saved, N: len(saved), Size: in.Size, Model: in.Model}
+	return writeJSON(out)
+}
+
+func httpTimeout() time.Duration {
+	to := strings.TrimSpace(os.Getenv("OAI_HTTP_TIMEOUT"))
+	if to == "" {
+		return 120 * time.Second
+	}
+	if d, err := time.ParseDuration(to); err == nil {
+		return d
+	}
+	return 120 * time.Second
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func shouldRetryStatus(code int) bool {
+	if code == 429 {
+		return true
+	}
+	if code >= 500 {
+		return true
+	}
+	return false
+}
+
+func backoffDelay(attempt int) time.Duration {
+	switch attempt {
+	case 0:
+		return 250 * time.Millisecond
+	case 1:
+		return 500 * time.Millisecond
+	default:
+		return 1 * time.Second
+	}
+}
+
+func isTruthyEnv(key string) bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	switch v {
+	case "1", "true", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func decodeStdB64(s string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(s)
+}
+
+func writeJSON(v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	fmt.Println(string(b))
+	return nil
+}
+
+// sanitizeExtras filters a map to only include string keys with primitive
+// JSON types: string, float64 (numbers), bool. It also allows nulls and
+// rejects nested arrays/objects to keep the request predictable.
+func sanitizeExtras(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		if strings.TrimSpace(k) == "" {
+			continue
+		}
+		switch tv := v.(type) {
+		case string:
+			out[k] = tv
+		case bool:
+			out[k] = tv
+		case float64:
+			// json.Unmarshal decodes all numbers into float64 by default
+			out[k] = tv
+		case int, int32, int64, uint, uint32, uint64:
+			// In practice, numbers arrive as float64, but accept ints as well
+			out[k] = tv
+		case nil:
+			out[k] = nil
+		default:
+			// drop arrays, maps, and unknown types
+		}
+	}
+	return out
+}

--- a/tools/cmd/img_create/img_create_test.go
+++ b/tools/cmd/img_create/img_create_test.go
@@ -1,0 +1,378 @@
+//nolint:errcheck // Tests elide error checks on JSON encoders/decoders where not relevant to the assertion under test.
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/hyperifyio/goagent/tools/testutil"
+)
+
+func buildTool(t *testing.T) string {
+	// Build this package into a temp binary
+	bin := filepath.Join(t.TempDir(), "img_create-test-bin")
+	cmd := exec.Command("go", "build", "-o", bin, ".")
+	cmd.Dir = "."
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, string(out))
+	}
+	return bin
+}
+
+func runTool(t *testing.T, bin string, in any, env map[string]string) (stdout, stderr string, code int) {
+	data, _ := json.Marshal(in)
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(data)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	if env != nil {
+		e := os.Environ()
+		for k, v := range env {
+			e = append(e, k+"="+v)
+		}
+		cmd.Env = e
+	}
+	err := cmd.Run()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			code = ee.ExitCode()
+		} else {
+			code = 1
+		}
+	}
+	return outBuf.String(), errBuf.String(), code
+}
+
+func TestMissingPrompt(t *testing.T) {
+	bin := buildTool(t)
+	_, stderr, code := runTool(t, bin, map[string]any{}, nil)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "prompt is required") {
+		t.Fatalf("expected prompt error, got %q", stderr)
+	}
+}
+
+func TestHappyPath_SaveOnePNG(t *testing.T) {
+	// 1x1 transparent PNG
+	png1x1 := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9cFmgAAAAASUVORK5CYII="
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/images/generations" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var req struct {
+			Model      string `json:"model"`
+			Prompt     string `json:"prompt"`
+			N          int    `json:"n"`
+			Size       string `json:"size"`
+			RespFmt    string `json:"response_format"`
+			Background string `json:"background"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("bad json: %v", err)
+		}
+		if req.Model != "gpt-image-1" || req.Prompt != "tiny-pixel" || req.N != 1 || req.Size != "1024x1024" || req.RespFmt != "b64_json" {
+			t.Fatalf("unexpected payload: %+v", req)
+		}
+		if req.Background != "transparent" {
+			t.Fatalf("expected extras merged: background=transparent, got %q", req.Background)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data":  []map[string]any{{"b64_json": png1x1}},
+			"model": "gpt-image-1",
+		})
+	}))
+	defer srv.Close()
+
+	bin := buildTool(t)
+	outDir := testutil.MakeRepoRelTempDir(t, "imgcreate-out-")
+	stdout, stderr, code := runTool(t, bin, map[string]any{
+		"prompt": "tiny-pixel",
+		"save":   map[string]any{"dir": outDir, "basename": "img", "ext": "png"},
+		"extras": map[string]any{"background": "transparent"},
+	}, map[string]string{
+		"OAI_IMAGE_BASE_URL": srv.URL,
+		"OAI_API_KEY":        "test-123",
+	})
+	if code != 0 {
+		t.Fatalf("unexpected failure: %s", stderr)
+	}
+	var obj struct {
+		Saved []struct {
+			Path   string `json:"path"`
+			Bytes  int    `json:"bytes"`
+			Sha256 string `json:"sha256"`
+		} `json:"saved"`
+		N     int    `json:"n"`
+		Size  string `json:"size"`
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &obj); err != nil {
+		t.Fatalf("bad stdout json: %v; raw=%q", err, stdout)
+	}
+	if obj.N != 1 || len(obj.Saved) != 1 {
+		t.Fatalf("unexpected saved count: %+v", obj)
+	}
+	// Verify file exists and bytes match decoded b64
+	got, err := os.ReadFile(obj.Saved[0].Path)
+	if err != nil {
+		t.Fatalf("read saved file: %v", err)
+	}
+	want, _ := base64.StdEncoding.DecodeString(png1x1)
+	if len(got) != len(want) {
+		t.Fatalf("bytes mismatch: got %d want %d", len(got), len(want))
+	}
+}
+
+func TestExtras_DoNotOverrideCoreKeys_AndSanitize(t *testing.T) {
+	// Server returns a trivial valid image
+	png1x1 := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9cFmgAAAAASUVORK5CYII="
+	var captured map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("bad json: %v", err)
+		}
+		captured = req
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"b64_json": png1x1}},
+		})
+	}))
+	defer srv.Close()
+
+	bin := buildTool(t)
+	outDir := testutil.MakeRepoRelTempDir(t, "imgcreate-out-")
+	_, stderr, code := runTool(t, bin, map[string]any{
+		"prompt": "tiny",
+		"n":      2,
+		"size":   "512x512",
+		"model":  "gpt-image-1",
+		"save":   map[string]any{"dir": outDir},
+		"extras": map[string]any{
+			"prompt":          "OVERRIDE-ATTEMPT",
+			"n":               99,
+			"size":            "2048x2048",
+			"response_format": "raw",
+			"ok_string":       "yes",
+			"ok_number":       1.5,
+			"ok_bool":         true,
+			"drop_obj":        map[string]any{"x": 1},
+			"drop_arr":        []any{1, 2, 3},
+		},
+	}, map[string]string{
+		"OAI_IMAGE_BASE_URL": srv.URL,
+	})
+	if code != 0 {
+		t.Fatalf("unexpected failure: %s", stderr)
+	}
+	// Core keys must remain as provided in top-level fields
+	if captured["prompt"] != "tiny" || captured["n"].(float64) != 2 || captured["size"] != "512x512" || captured["response_format"] != "b64_json" {
+		t.Fatalf("core keys overridden by extras: %+v", captured)
+	}
+	if captured["ok_string"] != "yes" || captured["ok_bool"] != true {
+		t.Fatalf("expected sanitized primitives present: %+v", captured)
+	}
+	if _, ok := captured["drop_obj"]; ok {
+		t.Fatalf("unexpected object in extras: %+v", captured)
+	}
+	if _, ok := captured["drop_arr"]; ok {
+		t.Fatalf("unexpected array in extras: %+v", captured)
+	}
+}
+
+func TestMissingSaveDir_WhenReturnB64False(t *testing.T) {
+	bin := buildTool(t)
+	// Default return_b64 is false; omit save to trigger validation error
+	_, stderr, code := runTool(t, bin, map[string]any{
+		"prompt": "tiny",
+	}, nil)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "save.dir is required when return_b64=false") {
+		t.Fatalf("expected save.dir error, got %q", stderr)
+	}
+}
+
+func TestInvalidSizePattern(t *testing.T) {
+	bin := buildTool(t)
+	// Provide an invalid size and set return_b64 to bypass save requirements
+	_, stderr, code := runTool(t, bin, map[string]any{
+		"prompt":     "tiny",
+		"size":       "big",
+		"return_b64": true,
+	}, nil)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "size must match") {
+		t.Fatalf("expected size pattern error, got %q", stderr)
+	}
+}
+
+func TestAPI400_JSONErrorIsSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"message": "bad prompt"},
+		})
+	}))
+	defer srv.Close()
+
+	bin := buildTool(t)
+	outDir := testutil.MakeRepoRelTempDir(t, "imgcreate-out-")
+	_, stderr, code := runTool(t, bin, map[string]any{
+		"prompt": "tiny",
+		"save":   map[string]any{"dir": outDir, "basename": "img", "ext": "png"},
+	}, map[string]string{
+		"OAI_IMAGE_BASE_URL": srv.URL,
+		"OAI_API_KEY":        "test-123",
+	})
+	if code == 0 {
+		t.Fatalf("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "bad prompt") {
+		t.Fatalf("expected API error message surfaced, got %q", stderr)
+	}
+}
+
+func TestSaveDir_AbsolutePathRejected(t *testing.T) {
+	bin := buildTool(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	abs := filepath.Join(wd, "imgcreate-abs-out")
+	// Ensure absolute path
+	if !filepath.IsAbs(abs) {
+		t.Fatalf("expected absolute path, got %q", abs)
+	}
+	_, stderr, code := runTool(t, bin, map[string]any{
+		"prompt": "tiny",
+		"save":   map[string]any{"dir": abs},
+	}, map[string]string{
+		"OAI_IMAGE_BASE_URL": "http://127.0.0.1:9", // invalid to avoid real network if it would try
+	})
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for absolute save.dir")
+	}
+	if !strings.Contains(stderr, "repo-relative") {
+		t.Fatalf("expected repo-relative error, got %q", stderr)
+	}
+}
+
+func TestSaveDir_EscapeOutsideRepoRejected(t *testing.T) {
+	bin := buildTool(t)
+	_, stderr, code := runTool(t, bin, map[string]any{
+		"prompt": "tiny",
+		"save":   map[string]any{"dir": filepath.Clean(filepath.Join(".."))},
+	}, map[string]string{
+		"OAI_IMAGE_BASE_URL": "http://127.0.0.1:9",
+	})
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for escape path")
+	}
+	if !strings.Contains(stderr, "escapes repository root") {
+		t.Fatalf("expected escape error, got %q", stderr)
+	}
+}
+
+func TestSaveDir_CleansRelativeAndCreatesNested_WithSHA256(t *testing.T) {
+	// 1x1 transparent PNG bytes and known SHA256
+	png1x1 := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9cFmgAAAAASUVORK5CYII="
+	wantBytes, _ := base64.StdEncoding.DecodeString(png1x1)
+	sum := sha256.Sum256(wantBytes)
+	wantSHA := hex.EncodeToString(sum[:])
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data":  []map[string]any{{"b64_json": png1x1}},
+			"model": "gpt-image-1",
+		})
+	}))
+	defer srv.Close()
+
+	bin := buildTool(t)
+	base := testutil.MakeRepoRelTempDir(t, "imgcreate-nested-")
+	// Provide a dir that cleans to a simple child (e.g., a/../b -> b)
+	nested := filepath.Join(base, "a", "..", "b")
+	stdout, stderr, code := runTool(t, bin, map[string]any{
+		"prompt": "tiny-pixel",
+		"save":   map[string]any{"dir": nested, "basename": "img"},
+	}, map[string]string{
+		"OAI_IMAGE_BASE_URL": srv.URL,
+		"OAI_API_KEY":        "test-123",
+	})
+	if code != 0 {
+		t.Fatalf("unexpected failure: %s", stderr)
+	}
+	var obj struct {
+		Saved []struct {
+			Path   string `json:"path"`
+			Bytes  int    `json:"bytes"`
+			Sha256 string `json:"sha256"`
+		} `json:"saved"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &obj); err != nil {
+		t.Fatalf("bad stdout json: %v; raw=%q", err, stdout)
+	}
+	if len(obj.Saved) != 1 {
+		t.Fatalf("expected one saved file, got %d", len(obj.Saved))
+	}
+	if obj.Saved[0].Sha256 != wantSHA {
+		t.Fatalf("sha256 mismatch: got %s want %s", obj.Saved[0].Sha256, wantSHA)
+	}
+	// Path should be repo-relative (not absolute)
+	if filepath.IsAbs(obj.Saved[0].Path) {
+		t.Fatalf("expected relative saved path, got absolute: %q", obj.Saved[0].Path)
+	}
+	// Ensure nested directories were created; file exists
+	if _, err := os.Stat(obj.Saved[0].Path); err != nil {
+		t.Fatalf("stat saved file: %v", err)
+	}
+}
+
+func TestBasename_MustNotContainPathSeparators(t *testing.T) {
+	// Need a server so the tool reaches save-path validation after decoding
+	png1x1 := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9cFmgAAAAASUVORK5CYII="
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"b64_json": png1x1}},
+		})
+	}))
+	defer srv.Close()
+
+	bin := buildTool(t)
+	outDir := testutil.MakeRepoRelTempDir(t, "imgcreate-out-")
+	badBase := "bad/name"
+	// On Windows also try using backslash explicitly
+	if runtime.GOOS == "windows" {
+		badBase = "bad\\name"
+	}
+	_, stderr, code := runTool(t, bin, map[string]any{
+		"prompt":     "tiny",
+		"save":       map[string]any{"dir": outDir, "basename": badBase},
+		"return_b64": false,
+	}, map[string]string{
+		"OAI_IMAGE_BASE_URL": srv.URL,
+	})
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for basename with separator")
+	}
+	if !strings.Contains(stderr, "basename must not contain path separators") {
+		t.Fatalf("expected basename separator error, got %q", stderr)
+	}
+}


### PR DESCRIPTION
Adds tools/cmd/img_create (image generation tool) and docs/reference/img_create.md.

Scope
- Validates input (prompt, n, size, repo-relative save.dir)
- Calls Images API with retries and extracts b64
- Saves PNGs with atomic writes and returns paths + sha256, or returns b64 (elided by default)

Notes
- Draft pending scaffolding/tests utilities already tracked in earlier PRs.
- Independent; touches only tool dir + its reference doc.

Tracking: FEATURE_CHECKLIST.md (tool: img_create)