### PR TITLE
Docs: security & runbooks (Linux 5.4 sandbox + research tools)

### DIFF
--- a/docs/runbooks/linux-5.4-sandbox-compatibility.md
+++ b/docs/runbooks/linux-5.4-sandbox-compatibility.md
@@ -1,0 +1,108 @@
+# Linux 5.4 sandbox compatibility and policy authoring
+
+This document explains compatibility constraints for Linux 5.4-era kernels, supported network modes and their caveats, how the execution bundle works (including inclusion of `agentcli`), how to author sandbox policies, and known limitations of rootless operation.
+
+## Why this matters
+
+Many servers and CI runners still use Linux 5.4 LTS. Certain modern sandboxing features like Landlock are unavailable, and user namespaces behave differently across distributions. This guide documents a safe, portable baseline.
+
+## Kernel constraints (Linux ≥ 5.4)
+
+- No Landlock: do not rely on Landlock file restrictions. Use chroot + bind mounts instead.
+- No overlayfs-in-userns: avoid overlayfs inside unprivileged user namespaces. Use bind mounts and tmpfs.
+- User namespaces: require unprivileged user namespaces enabled (`kernel.unprivileged_userns_clone=1`).
+- Seccomp: available and recommended for syscall filtering, but ensure your kernel config includes seccomp.
+- CLONE_NEWNET: unprivileged network namespaces may be disabled by distro; detect at runtime and fall back.
+
+### Troubleshooting kernel prerequisites
+
+- Enable user namespaces:
+  - Ubuntu/Debian: `sudo sysctl -w kernel.unprivileged_userns_clone=1 && echo kernel.unprivileged_userns_clone=1 | sudo tee /etc/sysctl.d/99-userns.conf`
+- Check seccomp: `grep SECCOMP /boot/config-$(uname -r)` should show `CONFIG_SECCOMP=y` and `CONFIG_SECCOMP_FILTER=y`.
+- Check newnet: attempt `unshare -n true`; if it fails with EPERM, network namespaces for unprivileged users are blocked.
+
+## Network modes
+
+- off: no network allowed. Prefer this for tools that do not need network access.
+- allow_all: do not create a network namespace; outbound egress allowed subject to host firewall. Less strict.
+- proxy_allowlist: route traffic via an HTTP(S) proxy that enforces destination allowlists. Use when selective egress is required on hosts without unprivileged `CLONE_NEWNET`.
+
+Caveats:
+- On systems without unprivileged network namespaces, `off` still works; `proxy_allowlist` requires a reachable proxy.
+- DNS resolution and time may vary by container/VM; prefer explicit IP:port and TLS verification where possible.
+
+## Bundle assembly overview
+
+On each run, `agentcli` assembles a minimal bundle directory with subdirs `bin`, `etc`, `in`, `out`, `tmp`. It copies exactly allowlisted tool executables and a copy of the current `agentcli` binary into `bin`. Only `/bundle/bin` is executable; other mounts are `noexec`.
+
+- Verify executables are regular files, reject symlinks.
+- Enforce ELF arch matches the running OS and architecture.
+- Cap total bundle size to prevent abuse.
+- Generate a manifest with file paths, sizes, and SHA-256 hashes.
+
+## Policy authoring
+
+A deny-by-default sandbox policy defines filesystem, environment, resources, and network:
+
+```json
+{
+  "filesystem": {
+    "bundle": { "binaries": [ "/usr/bin/jq" ] },
+    "inputs": [ { "host": "/etc/ssl/certs/ca-certificates.crt", "guest": "/etc/ssl/certs/ca.pem" } ],
+    "outputs": [ "/out/result.json" ]
+  },
+  "env": { "allow": [ "TZ", "HTTP_PROXY=http://127.0.0.1:8080" ] },
+  "resources": { "timeoutSec": 10, "max_output_bytes": 1048576, "rlimits": { "NOFILE": 256, "NPROC": 64, "AS": 268435456 } },
+  "network": { "mode": "off", "allow": [] },
+  "audit": { "redact": [ "OAI_API_KEY" ] }
+}
+```
+
+Guidelines:
+- Only list absolute host paths under `filesystem.bundle.binaries` and ensure they are static binaries when possible.
+- Use `filesystem.inputs[]` for read-only mounts; avoid mounting broad directories.
+- Constrain outputs to a small set under `/out`.
+- Keep env allowlist minimal. Prefer literal `NAME=value` for one-off overrides.
+- Set tight timeouts and rlimits appropriate for the tool.
+- Prefer `network.mode: off` unless network is essential.
+
+## Rootless limitations
+
+- cgroups: only available if delegated by the system; otherwise CPU/memory limits may be advisory only.
+- Mounts: require user namespaces; without them, mount operations will fail for unprivileged users.
+- No raw sockets, no ptrace, limited `fork()` scale; design tools to be short-lived and modest in resource consumption.
+
+## Copy-paste examples
+
+- Minimal offline run with no network and one input file:
+
+```bash
+cat > policy.json <<'JSON'
+{
+  "filesystem": {
+    "bundle": { "binaries": [ "/usr/bin/jq" ] },
+    "inputs": [ { "host": "$(pwd)/in.json", "guest": "/in/in.json" } ],
+    "outputs": [ "/out/out.json" ]
+  },
+  "env": { "allow": [ "TZ=UTC" ] },
+  "resources": { "timeoutSec": 5, "rlimits": { "NOFILE": 128 } },
+  "network": { "mode": "off" }
+}
+JSON
+
+./bin/agentcli -prompt 'Process input with jq' -tools ./tools.json -debug
+```
+
+- Proxy allowlist mode sketch:
+
+```bash
+export HTTPS_PROXY=http://127.0.0.1:8080
+# Proxy must enforce destination allowlists externally.
+```
+
+## Troubleshooting checklist
+
+- EPERM creating namespaces: switch to `allow_all` or `proxy_allowlist`; document risk.
+- Read-only filesystem errors: write only under `/out` or `/tmp`.
+- Missing binary dependencies: rebuild tools statically or enable dynamic dependency copying in the bundle.
+- Timeouts: increase `resources.timeoutSec` conservatively; investigate tool performance.

--- a/docs/security/research-tools.md
+++ b/docs/security/research-tools.md
@@ -1,0 +1,60 @@
+# Security posture for research tools
+
+This page documents the security posture, guardrails, and operational guidance for the CLI-only research tools (e.g., `searxng_search`, `http_fetch`, `robots_check`, `readability_extract`, `metadata_extract`, `pdf_extract`, `rss_fetch`, `wayback_lookup`, `wiki_query`, `openalex_search`, `crossref_search`, `dedupe_rank`, `citation_pack`). It complements the broader threat model by focusing on network egress safety, provenance, and audit discipline for web-facing tools.
+
+## Network egress and SSRF protections
+
+Tools that reach the network must enforce a strict allowlist for schemes and a denylist for address families to prevent SSRF and lateral movement:
+
+- Allowed schemes: `http`, `https` only. All others are rejected.
+- Denylist targets (reject both direct IPs and DNS results that resolve to these ranges):
+  - Loopback: `127.0.0.0/8`, `::1/128`
+  - RFC1918 private IPv4: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+  - Link-local: `169.254.0.0/16` (IPv4), `fe80::/10` (IPv6)
+  - Unique local IPv6 (RFC4193): `fc00::/7`
+  - Multicast/broadcast and unspecified: `224.0.0.0/4`, `ff00::/8`, `255.255.255.255`, `0.0.0.0`, `::`
+  - Tor/onion services: hostnames ending in `.onion`
+- Redirect handling: follow at most 5 redirects and re-apply SSRF checks on each hop before connecting.
+- DNS rebinding protection: resolve the destination host and validate every resolved address against the denylist; reject when any hop resolves to a blocked range.
+- Byte caps and timeouts: enforce tool-specific response size caps and sane timeouts; prefer connection + overall deadlines over idle timeouts.
+
+## Robots compliance
+
+- Respect `robots.txt` per RFC 9309. Evaluate rules using the effective origin of the fetch, preferring the most specific user-agent group.
+- Use `robots_check` to determine `allowed` and optional `crawl_delay_ms` before `http_fetch` or other network retrievals when applicable.
+- Do not follow redirects to a different origin for `robots.txt` evaluation.
+
+## Outbound User-Agent and etiquette
+
+- Each tool sends a distinct User-Agent: `agentcli-<tool-name>/0.1` (e.g., `agentcli-searxng/0.1`, `agentcli-http-fetch/0.1`).
+- Honor server guidance: handle `Retry-After` on 429/503; back off with capped retries as specified per tool.
+- Keep requests minimal and purpose-limited; avoid fetching binary content unless explicitly required by the tool.
+
+## Audit logging and redaction policy
+
+- All networked tools emit structured NDJSON audit records with fields appropriate to the tool. Common fields include:
+  - `ts` (RFC3339 UTC timestamp)
+  - `tool` (string)
+  - `url_host` (hostname only)
+  - Operation-specific fields (e.g., `status`, `bytes`, `ms`, `retries`, `truncated`, `saved`)
+- Redaction rules:
+  - Never log secrets or tokens. Do not include full URLs with query parameters when they may contain credentials; prefer host-only or redact sensitive keys.
+  - For potentially sensitive queries (e.g., long search strings), truncate beyond 256 characters and include `query_truncated: true`.
+  - Base64 payloads and large bodies are never written to audit logs.
+
+## Environment and sandboxing guidance
+
+- Pass only an explicit allowlist of environment variables per-tool via `envPassthrough`. Avoid ambient secrets.
+- Run tools as an unprivileged user. Consider containerization, user namespaces, or seccomp/AppArmor where feasible.
+- Constrain filesystem effects to repository-relative paths validated against traversal and symlink escapes.
+- Apply process-level limits (ulimits) and per-invocation time/size caps to prevent resource abuse.
+
+## Deterministic behavior and retries
+
+- Enforce hard redirect limits, bounded retries with jitter on transient errors (e.g., timeouts, 429, 5xx), and clear non-zero exits with single-line JSON on stderr describing the error.
+- Keep stdout schema stable and validated; treat deviations as errors.
+
+## Related documents
+
+- Threat model and trust boundaries: see [security/threat-model.md](threat-model.md)
+- Tool reference for stdin/stdout schemas and env passthrough: see [reference/research-tools.md](../reference/research-tools.md)


### PR DESCRIPTION
## Scope
- Add \ (kernel constraints, network modes, bundle contents, policy authoring, rootless caveats)
- Add \ (threat model, SSRF guards, retries, input validation)

## Risk
- Low; documentation-only

## Testing
- Rendered locally on GitHub preview; links resolve

Tracks the related items in \ and \.