### PR TITLE
ADR-0012: State dir persistence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,65 @@
+# Documentation Index
+
+This docs index helps you navigate architecture notes and diagrams.
+
+- ADR-0001: Minimal Agent CLI — design context, decisions, and contracts.
+  - Link: [docs/adr/0001-minimal-agent-cli.md](adr/0001-minimal-agent-cli.md)
+- ADR-0002: Unrestricted toolbelt (files + network) — risks, contracts, and guidance.
+  - Link: [docs/adr/0002-unrestricted-toolbelt.md](adr/0002-unrestricted-toolbelt.md)
+- ADR-0003: Toolchain & Lint Policy (Go + golangci-lint) — pin Go via go.mod and a known-good golangci-lint; CI and local workflows align.
+  - Link: [docs/adr/0003-toolchain-and-lint-policy.md](adr/0003-toolchain-and-lint-policy.md)
+- ADR-0004: Default LLM Call Policy — default temperature 1.0, capability-based omission, one-knob rule, and observability fields.
+  - Link: [docs/adr/0004-default-llm-policy.md](adr/0004-default-llm-policy.md)
+- ADR-0005: Harmony pre-processing and channel-aware output — pre-stage HTTP call, parallel read-only tools, validator/audit with stage tags, and deterministic channel routing.
+  - Link: [docs/adr/0005-harmony-pre-processing-and-channel-aware-output.md](adr/0005-harmony-pre-processing-and-channel-aware-output.md)
+ - ADR-0006: Image generation tool (img_create) — minimal Images API integration, repo‑relative saves, env passthrough, and transcript hygiene.
+   - Link: [docs/adr/0006-image-generation-tool-img_create.md](adr/0006-image-generation-tool-img_create.md)
+ - ADR-0010: Adopt SearXNG & network research toolbelt (CLI-only) — credible web discovery with provenance via SearXNG and a safe, CLI-only toolbelt.
+   - Link: [docs/adr/0010-research-tools-searxng.md](adr/0010-research-tools-searxng.md)
+ - ADR-0011: State bundle schema — versioned on-disk JSON snapshots for reproducible runs.
+   - Link: [docs/adr/0011-state-bundle-schema.md](adr/0011-state-bundle-schema.md)
+ - ADR-0012: Persist and refine execution state via -state-dir — file-based snapshots with scopes, restore-before-prep, and refinement controls.
+   - Link: [docs/adr/0012-state-dir-persistence.md](adr/0012-state-dir-persistence.md)
+- Sequence diagrams: agent flow and toolbelt interactions.
+  - Link: [docs/diagrams/agentcli-seq.md](diagrams/agentcli-seq.md)
+  - Link: [docs/diagrams/toolbelt-seq.md](diagrams/toolbelt-seq.md)
+  - Link: [docs/diagrams/harmony-prep-seq.md](diagrams/harmony-prep-seq.md)
+  - Link: [docs/diagrams/research-pipeline.md](diagrams/research-pipeline.md)
+  - Link: [docs/diagrams/prestage_flow.md](diagrams/prestage_flow.md)
+
+- Architecture: Module boundaries and allowed imports between layers.
+  - Link: [docs/architecture/module-boundaries.md](architecture/module-boundaries.md)
+
+- Tools manifest reference: precise `tools.json` schema and mapping to OpenAI tools.
+  - Link: [docs/reference/tools-manifest.md](reference/tools-manifest.md)
+ 
+ - CLI reference: complete flag list, env precedence, exit codes.
+   - Link: [docs/reference/cli-reference.md](reference/cli-reference.md)
+
+- Tool reference: Image generation tool (`img_create`).
+  - Link: [docs/reference/img_create.md](reference/img_create.md)
+- Tool reference: HTTP fetch (`http_fetch`).
+  - Link: [docs/reference/http_fetch.md](reference/http_fetch.md)
+- Tool reference: SearXNG search (`searxng_search`).
+  - Link: [docs/reference/searxng_search.md](reference/searxng_search.md)
+- Tool reference: Crossref search (`crossref_search`).
+  - Link: [docs/reference/crossref_search.md](reference/crossref_search.md)
+ - Tool reference: PDF extract (`pdf_extract`).
+   - Link: [docs/reference/pdf_extract.md](reference/pdf_extract.md)
+ - Tool reference: Wayback lookup (`wayback_lookup`).
+   - Link: [docs/reference/wayback_lookup.md](reference/wayback_lookup.md)
+
+- Security: Threat model and trust boundaries.
+  - Link: [docs/security/threat-model.md](security/threat-model.md)
+
+- Runbooks: Troubleshooting common errors and fixes.
+  - Link: [docs/runbooks/troubleshooting.md](runbooks/troubleshooting.md)
+
+- Migrations: Tools layout (legacy → canonical `tools/cmd/*` + `tools/bin/*`).
+  - Link: [docs/migrations/tools-layout.md](migrations/tools-layout.md)
+
+Additional guides will be added here as they are created.
+
+Model parameter compatibility
+
+Some reasoning-oriented models may not accept sampling parameters. The agent omits `temperature` automatically for such models while keeping the default of 1.0 for compatible families (e.g., GPT-5 variants). This avoids API errors and preserves expected defaults where applicable.

--- a/docs/adr/0012-state-dir-persistence.md
+++ b/docs/adr/0012-state-dir-persistence.md
@@ -1,0 +1,135 @@
+# ADR-0012: Persist and refine execution state via -state-dir
+
+## Status
+
+Accepted
+
+## Context
+
+We want deterministic, reproducible runs across CLI invocations without adding a database or introducing network/stateful dependencies. Operators frequently iterate on similar prompts and tool configurations; recomputing the pre-stage every time is wasteful and introduces variability. A simple file-based persistence mechanism, controlled explicitly by the user via `-state-dir`, enables:
+
+- Reusing prior refined prompts and settings for faster, stable runs
+- Explicit partitioning by scope to avoid cross-contamination
+- Offline, testable behavior with predictable artifacts suitable for diffs
+
+Security and privacy constraints require that we do not store raw request/response bodies or secrets by default, and that on-disk files have restrictive permissions.
+
+## Options
+
+- No persistence: always recompute pre-stage; simplest but slow and variable
+- Database-backed store: robust but heavy, adds operational complexity
+- File-based JSON bundles: lightweight, portable, easy to test/diff
+
+## Decision
+
+Adopt a file-based, append-only persistence under a user-provided `-state-dir`:
+
+- Snapshot files named `state-<RFC3339UTC>-<8charSHA>.json` containing a versioned `StateBundle` (`version:"1"`) per ADR‑0011
+- A pointer file `latest.json` with `{version:"1", path, sha256}` pointing to the newest snapshot
+- Directory permissions enforced to `0700`; files written with `0600`, using atomic write + fsync + rename
+- Partitioning via `scope_key`; default scope is a hash of `(model_id|base_url|toolset_hash)` with optional `-state-scope` override
+- Redaction and safety: API keys are redacted upstream; bundles exclude raw bodies; world-writable or non-owned directories are rejected
+- Refinement: `-state-refine` with either `-state-refine-text` or `-state-refine-file` produces a new snapshot with `prev_sha` pointing to the previous bundle
+
+See ADR‑0011 for the `StateBundle` schema details.
+
+## Consequences
+
+- Reproducible and faster repeated runs; fewer pre-stage calls when state is restored
+- Deterministic artifacts that are easy to inspect and test
+- Requires user selection of a secure directory; rejects unsafe permissions
+- Disk usage grows with snapshots; users can prune older snapshots manually
+
+## Sequence (Mermaid)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant U as User
+  participant C as agentcli
+  participant FS as -state-dir (filesystem)
+  participant LLM as Pre-stage LLM
+
+  rect rgb(245,245,245)
+    Note over C,FS: First run (no state)
+    U->>C: run with -state-dir
+    C->>FS: LoadLatestStateBundle(scope)
+    FS-->>C: (none)
+    C->>LLM: Pre-stage call (derive prompts/settings)
+    LLM-->>C: Harmony messages (validated)
+    C->>FS: SaveStateBundle(snapshot)
+    FS-->>C: latest.json -> snapshot
+    C-->>U: Execute main call with merged config
+  end
+
+  rect rgb(245,245,245)
+    Note over C,FS: Restore (no refine)
+    U->>C: run again with same scope
+    C->>FS: LoadLatestStateBundle(scope)
+    FS-->>C: bundle
+    C-->>U: Skip pre-stage; use restored prompts/settings
+  end
+
+  rect rgb(245,245,245)
+    Note over C,FS: Refine existing state
+    U->>C: run with -state-refine (-state-refine-text|file)
+    C->>FS: LoadLatestStateBundle(scope)
+    FS-->>C: bundle
+    C->>LLM: Pre-stage refine(prompt = refine-input)
+    LLM-->>C: refined messages/settings
+    C->>FS: SaveStateBundle(new, prev_sha=old)
+    FS-->>C: latest.json -> new snapshot
+    C-->>U: Proceed with refined config
+  end
+```
+
+## Usage examples
+
+Restore and reuse prompts/settings across runs:
+
+```bash
+./bin/agentcli \
+  -prompt "Summarize the repo" \
+  -tools ./tools.json \
+  -state-dir "$PWD/.agent-state" \
+  -debug
+
+# Second run with the same -state-dir and scope will restore and skip pre-stage
+./bin/agentcli \
+  -prompt "Summarize the repo" \
+  -tools ./tools.json \
+  -state-dir "$PWD/.agent-state"
+```
+
+Dry-run to see intended actions without touching disk:
+
+```bash
+./bin/agentcli -prompt "Say ok" -state-dir "$PWD/.agent-state" -dry-run
+```
+
+Refine an existing bundle using inline text:
+
+```bash
+./bin/agentcli \
+  -prompt "Summarize the repo" \
+  -state-dir "$PWD/.agent-state" \
+  -state-refine \
+  -state-refine-text "Tighten temperature to 0.2 and emphasize security notes"
+```
+
+Use a custom scope to keep contexts separate:
+
+```bash
+./bin/agentcli -prompt "Say ok" -state-dir "$PWD/.agent-state" -state-scope "docs-demo"
+```
+
+## Security notes
+
+- Use a private directory owned by the current user. The CLI rejects world-writable or non-owned directories.
+- Files are written `0600` and the directory is `0700`. Back up or copy with care.
+- Keys and secrets are redacted upstream; raw request/response bodies are not stored by default.
+
+## References
+
+- ADR‑0011: State bundle schema (`docs/adr/0011-state-bundle-schema.md`)
+- CLI flags reference (`docs/reference/cli-reference.md`)


### PR DESCRIPTION
Adds docs/adr/0012-state-dir-persistence.md and updates docs/README.md link. Scope: docs-only. Risk: low. Tests: none; CI doc checks only. Tracked in FEATURE_CHECKLIST.md.