### PR TITLE
State: versioned StateBundle schema (v1) with validation

### DIFF
--- a/internal/state/schema.go
+++ b/internal/state/schema.go
@@ -1,0 +1,73 @@
+package state
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// StateBundle is the versioned persisted execution state snapshot.
+// Only JSON-serializable fields; do not include runtime-only data.
+// Version must be "1" for the initial schema.
+// All timestamps are RFC3339 with UTC timezone.
+// Files must be written with permissions 0600.
+// The pointer file latest.json must contain a JSON object pointing to a concrete snapshot path.
+
+type StateBundle struct {
+	Version      string            `json:"version"`
+	CreatedAt    string            `json:"created_at"`
+	ToolVersion  string            `json:"tool_version"`
+	ModelID      string            `json:"model_id"`
+	BaseURL      string            `json:"base_url"`
+	ToolsetHash  string            `json:"toolset_hash"`
+	ScopeKey     string            `json:"scope_key"`
+	Prompts      map[string]string `json:"prompts"`
+	PrepSettings map[string]any    `json:"prep_settings"`
+	Context      map[string]any    `json:"context"`
+	ToolCaps     map[string]any    `json:"tool_caps"`
+	Custom       map[string]any    `json:"custom"`
+	SourceHash   string            `json:"source_hash"`
+	PrevSHA      string            `json:"prev_sha,omitempty"`
+}
+
+var (
+	errInvalidVersion   = errors.New("invalid version")
+	errMissingTimestamp = errors.New("invalid created_at")
+	errMissingModel     = errors.New("missing model_id")
+	errMissingBaseURL   = errors.New("missing base_url")
+	errMissingScope     = errors.New("missing scope_key")
+)
+
+// Validate returns nil if the bundle is structurally valid for version 1.
+func (b *StateBundle) Validate() error {
+	if b == nil {
+		return errors.New("nil bundle")
+	}
+	if b.Version != "1" {
+		return fmt.Errorf("%w: %s", errInvalidVersion, b.Version)
+	}
+	if _, err := time.Parse(time.RFC3339, b.CreatedAt); err != nil {
+		return errMissingTimestamp
+	}
+	if b.ModelID == "" {
+		return errMissingModel
+	}
+	if b.BaseURL == "" {
+		return errMissingBaseURL
+	}
+	if b.ScopeKey == "" {
+		return errMissingScope
+	}
+	// Optional maps may be nil; normalize callers should handle nil.
+	return nil
+}
+
+// ComputeSourceHash returns a hex-encoded SHA-256 of select identifying fields.
+// This is used to detect changes across runs; callers decide the exact input.
+func ComputeSourceHash(modelID string, baseURL string, toolsetHash string, scopeKey string) string {
+	input := modelID + "|" + baseURL + "|" + toolsetHash + "|" + scopeKey
+	sum := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/state/schema_test.go
+++ b/internal/state/schema_test.go
@@ -1,0 +1,52 @@
+package state
+
+import (
+	"testing"
+)
+
+func TestValidate_OK(t *testing.T) {
+	b := &StateBundle{
+		Version:     "1",
+		CreatedAt:   "2025-08-19T00:00:00Z",
+		ToolVersion: "dev",
+		ModelID:     "gpt-5",
+		BaseURL:     "https://api.openai.example/v1",
+		ToolsetHash: "abc123",
+		ScopeKey:    "scope",
+		Prompts:     map[string]string{"system": "s"},
+		SourceHash:  "deadbeef",
+	}
+	if err := b.Validate(); err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+}
+
+func TestValidate_Errors(t *testing.T) {
+	cases := []struct {
+		name string
+		b    StateBundle
+	}{
+		{"bad version", StateBundle{Version: "2", CreatedAt: "2025-08-19T00:00:00Z", ModelID: "m", BaseURL: "u", ScopeKey: "s"}},
+		{"bad ts", StateBundle{Version: "1", CreatedAt: "not-time", ModelID: "m", BaseURL: "u", ScopeKey: "s"}},
+		{"no model", StateBundle{Version: "1", CreatedAt: "2025-08-19T00:00:00Z", BaseURL: "u", ScopeKey: "s"}},
+		{"no base", StateBundle{Version: "1", CreatedAt: "2025-08-19T00:00:00Z", ModelID: "m", ScopeKey: "s"}},
+		{"no scope", StateBundle{Version: "1", CreatedAt: "2025-08-19T00:00:00Z", ModelID: "m", BaseURL: "u"}},
+	}
+	for _, tc := range cases {
+		if err := tc.b.Validate(); err == nil {
+			t.Fatalf("%s: expected error", tc.name)
+		}
+	}
+}
+
+func TestComputeSourceHash_Deterministic(t *testing.T) {
+	got1 := ComputeSourceHash("m", "u", "t", "s")
+	got2 := ComputeSourceHash("m", "u", "t", "s")
+	if got1 != got2 {
+		t.Fatalf("hash not deterministic: %s vs %s", got1, got2)
+	}
+	got3 := ComputeSourceHash("m2", "u", "t", "s")
+	if got1 == got3 {
+		t.Fatalf("hash should change on input change")
+	}
+}


### PR DESCRIPTION
## Scope
- Introduces `internal/state/schema.go` defining versioned `StateBundle` (v1)
- Adds `Validate()` and `ComputeSourceHash()` with unit tests

## Why
- Establishes minimal, self-contained state schema foundation

## Testing
- Ran: `go test ./internal/state -run 'Validate|ComputeSourceHash' -v` in clean worktree

## Tracking
- Tracked in `FEATURE_CHECKLIST.md` as a state schema code slice.