### PR TITLE
State: atomic save/load with secure dir + quarantine + advisory lock

### DIFF
--- a/internal/state/load.go
+++ b/internal/state/load.go
@@ -1,0 +1,125 @@
+package state
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrStateInvalid is returned when persisted state cannot be loaded safely.
+var ErrStateInvalid = errors.New("state invalid")
+
+// isBaseName returns true if p is a simple base name with no path separators
+// or parent traversal segments.
+func isBaseName(p string) bool {
+	if p == "" {
+		return false
+	}
+	if filepath.Base(p) != p {
+		return false
+	}
+	if strings.Contains(p, "..") {
+		return false
+	}
+	return true
+}
+
+// LoadLatestStateBundle loads the most recent state bundle from dir by reading
+// latest.json and then opening the referenced snapshot file. It validates the
+// pointer structure, verifies the snapshot hash when present, and validates the
+// bundle schema. On any issue (missing files, decode errors, version mismatch,
+// permission errors), it returns (nil, ErrStateInvalid).
+func LoadLatestStateBundle(dir string) (*StateBundle, error) {
+	// Security: reject insecure directories (world-writable or non-owned) on Unix
+	if err := ensureSecureStateDir(dir); err != nil {
+		return nil, ErrStateInvalid
+	}
+	// Best-effort lock to reduce concurrent writers/readers races
+	if unlock, lockErr := acquireStateLock(dir); lockErr == nil && unlock != nil {
+		defer unlock()
+	}
+	latestPath := filepath.Join(dir, "latest.json")
+	latestBytes, err := os.ReadFile(latestPath)
+	if err != nil {
+		// Missing latest.json is not a quarantinable corruption; caller can regenerate.
+		return nil, ErrStateInvalid
+	}
+
+	var ptr latestPointer
+	if err := json.Unmarshal(latestBytes, &ptr); err != nil {
+		// Partially written or corrupt latest.json → quarantine pointer for regeneration.
+		quarantineFile(latestPath)
+		return nil, ErrStateInvalid
+	}
+	if ptr.Version != "1" || !isBaseName(ptr.Path) {
+		// Unknown version or unsafe path → quarantine pointer.
+		quarantineFile(latestPath)
+		return nil, ErrStateInvalid
+	}
+
+	snapPath := filepath.Join(dir, ptr.Path)
+	snapBytes, err := os.ReadFile(snapPath)
+	if err != nil {
+		// Pointer to missing or unreadable snapshot → quarantine pointer.
+		quarantineFile(latestPath)
+		return nil, ErrStateInvalid
+	}
+
+	if ptr.SHA256 != "" {
+		sum := sha256.Sum256(snapBytes)
+		if !strings.EqualFold(hex.EncodeToString(sum[:]), ptr.SHA256) {
+			// Snapshot contents do not match recorded hash → quarantine snapshot and pointer.
+			quarantineFile(snapPath)
+			quarantineFile(latestPath)
+			return nil, ErrStateInvalid
+		}
+	}
+
+	var b StateBundle
+	if err := json.Unmarshal(snapBytes, &b); err != nil {
+		// Corrupt snapshot JSON → quarantine snapshot and pointer.
+		quarantineFile(snapPath)
+		quarantineFile(latestPath)
+		return nil, ErrStateInvalid
+	}
+	if err := b.Validate(); err != nil {
+		// Invalid bundle structure → quarantine snapshot and pointer.
+		quarantineFile(snapPath)
+		quarantineFile(latestPath)
+		return nil, ErrStateInvalid
+	}
+	return &b, nil
+}
+
+// quarantineFile renames the given path to a sibling with a ".quarantined" suffix.
+// If the target exists, it appends a numeric counter (e.g., .quarantined.1) up to 99 attempts.
+// Errors are returned only for unexpected conditions; callers typically ignore failures.
+func quarantineFile(path string) {
+	// Ensure we only operate within an existing directory and on a regular file when possible.
+	base := filepath.Base(path)
+	if base == "." || base == ".." || base == "" {
+		return
+	}
+	dir := filepath.Dir(path)
+	// Compute first candidate
+	cand := filepath.Join(dir, base+".quarantined")
+	if _, err := os.Stat(cand); err == nil {
+		// Find an available suffix
+		for i := 1; i < 100; i++ {
+			next := filepath.Join(dir, fmt.Sprintf("%s.quarantined.%d", base, i))
+			if _, err := os.Stat(next); os.IsNotExist(err) {
+				cand = next
+				break
+			}
+		}
+	}
+	// Attempt atomic rename; best-effort.
+	if err := os.Rename(path, cand); err != nil {
+		return
+	}
+}

--- a/internal/state/load_test.go
+++ b/internal/state/load_test.go
@@ -1,0 +1,258 @@
+package state
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func makeValidBundle(now string) *StateBundle {
+	return &StateBundle{
+		Version:     "1",
+		CreatedAt:   now,
+		ToolVersion: "test-1",
+		ModelID:     "gpt-5",
+		BaseURL:     "http://example.local",
+		ToolsetHash: "abc",
+		ScopeKey:    "scope-1",
+		Prompts:     map[string]string{"system": "hi"},
+		SourceHash:  ComputeSourceHash("gpt-5", "http://example.local", "abc", "scope-1"),
+	}
+}
+
+func TestLoadLatestStateBundle_OK(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
+	b := makeValidBundle(now)
+	if err := SaveStateBundle(dir, b); err != nil {
+		t.Fatalf("SaveStateBundle: %v", err)
+	}
+
+	got, err := LoadLatestStateBundle(dir)
+	if err != nil {
+		t.Fatalf("LoadLatestStateBundle error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("got nil bundle")
+	}
+	if got.Version != b.Version || got.CreatedAt != b.CreatedAt || got.ModelID != b.ModelID || got.BaseURL != b.BaseURL || got.ScopeKey != b.ScopeKey {
+		t.Fatalf("loaded bundle mismatch: %+v vs %+v", got, b)
+	}
+}
+
+func TestLoadLatestStateBundle_RejectsInsecureDir(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
+	b := makeValidBundle(now)
+	if err := SaveStateBundle(dir, b); err != nil {
+		t.Fatalf("SaveStateBundle: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(dir, 0o707); err != nil {
+			t.Fatalf("chmod: %v", err)
+		}
+		if got, err := LoadLatestStateBundle(dir); !errors.Is(err, ErrStateInvalid) || got != nil {
+			t.Fatalf("expected ErrStateInvalid and nil for insecure dir, got %v, %v", err, got)
+		}
+		// Fix perms and expect success
+		if err := os.Chmod(dir, 0o700); err != nil {
+			t.Fatalf("chmod fix: %v", err)
+		}
+	}
+	if got, err := LoadLatestStateBundle(dir); err != nil || got == nil {
+		t.Fatalf("LoadLatestStateBundle after fix: %v, %v", err, got)
+	}
+}
+
+func TestLoadLatestStateBundle_MissingLatest(t *testing.T) {
+	dir := t.TempDir()
+	if b, err := LoadLatestStateBundle(dir); !errors.Is(err, ErrStateInvalid) || b != nil {
+		t.Fatalf("expected ErrStateInvalid and nil, got %v, %v", err, b)
+	}
+}
+
+func TestLoadLatestStateBundle_CorruptLatest(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "latest.json"), []byte("not-json"), 0o600); err != nil {
+		t.Fatalf("write latest: %v", err)
+	}
+	if b, err := LoadLatestStateBundle(dir); !errors.Is(err, ErrStateInvalid) || b != nil {
+		t.Fatalf("expected ErrStateInvalid and nil, got %v, %v", err, b)
+	}
+	// Corrupt pointer should be quarantined
+	if _, err := os.Stat(filepath.Join(dir, "latest.json.quarantined")); err != nil {
+		t.Fatalf("expected quarantined latest.json, err=%v", err)
+	}
+}
+
+func TestLoadLatestStateBundle_UnknownVersion(t *testing.T) {
+	dir := t.TempDir()
+	// Write a valid snapshot first
+	now := time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
+	b := makeValidBundle(now)
+	if err := SaveStateBundle(dir, b); err != nil {
+		t.Fatalf("SaveStateBundle: %v", err)
+	}
+	// Overwrite latest.json with version 2
+	// Discover snapshot file name
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var snapshot string
+	for _, e := range entries {
+		if !e.IsDir() && e.Name() != "latest.json" {
+			snapshot = e.Name()
+			break
+		}
+	}
+	ptr := latestPointer{Version: "2", Path: snapshot, SHA256: "deadbeef"}
+	data, err := json.Marshal(ptr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "latest.json"), data, 0o600); err != nil {
+		t.Fatalf("write latest: %v", err)
+	}
+
+	if b2, err := LoadLatestStateBundle(dir); !errors.Is(err, ErrStateInvalid) || b2 != nil {
+		t.Fatalf("expected ErrStateInvalid and nil, got %v, %v", err, b2)
+	}
+	// Unknown version pointer should be quarantined
+	if _, err := os.Stat(filepath.Join(dir, "latest.json.quarantined")); err != nil {
+		t.Fatalf("expected quarantined latest.json, err=%v", err)
+	}
+}
+
+func TestLoadLatestStateBundle_MissingSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	// Write pointer to missing file
+	ptr := latestPointer{Version: "1", Path: "missing.json", SHA256: ""}
+	data, err := json.Marshal(ptr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "latest.json"), data, 0o600); err != nil {
+		t.Fatalf("write latest: %v", err)
+	}
+	if b, err := LoadLatestStateBundle(dir); !errors.Is(err, ErrStateInvalid) || b != nil {
+		t.Fatalf("expected ErrStateInvalid and nil, got %v, %v", err, b)
+	}
+	// Pointer should be quarantined
+	if _, err := os.Stat(filepath.Join(dir, "latest.json.quarantined")); err != nil {
+		t.Fatalf("expected quarantined latest.json, err=%v", err)
+	}
+}
+
+func TestLoadLatestStateBundle_PermissionDenied(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows permissions semantics differ")
+	}
+	dir := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
+	b := makeValidBundle(now)
+	if err := SaveStateBundle(dir, b); err != nil {
+		t.Fatalf("SaveStateBundle: %v", err)
+	}
+	// Find snapshot and chmod to 000 to induce EPERM when reading
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var snapshot string
+	for _, e := range entries {
+		if !e.IsDir() && e.Name() != "latest.json" {
+			snapshot = e.Name()
+			break
+		}
+	}
+	snapPath := filepath.Join(dir, snapshot)
+	if err := os.Chmod(snapPath, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(snapPath, 0o600); err != nil {
+			t.Logf("ignored chmod restore error: %v", err)
+		}
+	})
+
+	if b2, err := LoadLatestStateBundle(dir); !errors.Is(err, ErrStateInvalid) || b2 != nil {
+		t.Fatalf("expected ErrStateInvalid and nil, got %v, %v", err, b2)
+	}
+}
+
+func TestLoadLatestStateBundle_SnapshotHashMismatch_QuarantineBoth(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
+	b := makeValidBundle(now)
+	if err := SaveStateBundle(dir, b); err != nil {
+		t.Fatalf("SaveStateBundle: %v", err)
+	}
+	// Tamper with snapshot contents to break SHA
+	// Find snapshot name
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var snapshot string
+	for _, e := range entries {
+		if !e.IsDir() && e.Name() != "latest.json" {
+			snapshot = e.Name()
+			break
+		}
+	}
+	if snapshot == "" {
+		t.Fatalf("snapshot not found")
+	}
+	snapPath := filepath.Join(dir, snapshot)
+	if err := os.WriteFile(snapPath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("tamper snapshot: %v", err)
+	}
+	if b2, err := LoadLatestStateBundle(dir); !errors.Is(err, ErrStateInvalid) || b2 != nil {
+		t.Fatalf("expected ErrStateInvalid and nil, got %v, %v", err, b2)
+	}
+	if _, err := os.Stat(snapPath + ".quarantined"); err != nil {
+		t.Fatalf("expected quarantined snapshot, err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "latest.json.quarantined")); err != nil {
+		t.Fatalf("expected quarantined latest.json, err=%v", err)
+	}
+}
+
+func TestLoadLatestStateBundle_CorruptSnapshotJSON_QuarantineBoth(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
+	b := makeValidBundle(now)
+	if err := SaveStateBundle(dir, b); err != nil {
+		t.Fatalf("SaveStateBundle: %v", err)
+	}
+	// Locate snapshot and write invalid JSON
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var snapshot string
+	for _, e := range entries {
+		if !e.IsDir() && e.Name() != "latest.json" {
+			snapshot = e.Name()
+			break
+		}
+	}
+	snapPath := filepath.Join(dir, snapshot)
+	if err := os.WriteFile(snapPath, []byte("not-json"), 0o600); err != nil {
+		t.Fatalf("write corrupt snapshot: %v", err)
+	}
+	if b2, err := LoadLatestStateBundle(dir); !errors.Is(err, ErrStateInvalid) || b2 != nil {
+		t.Fatalf("expected ErrStateInvalid and nil, got %v, %v", err, b2)
+	}
+	if _, err := os.Stat(snapPath + ".quarantined"); err != nil {
+		t.Fatalf("expected quarantined snapshot, err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "latest.json.quarantined")); err != nil {
+		t.Fatalf("expected quarantined latest.json, err=%v", err)
+	}
+}

--- a/internal/state/lock.go
+++ b/internal/state/lock.go
@@ -1,0 +1,95 @@
+package state
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// acquireStateLock attempts to take a coarse-grained advisory lock for the
+// given directory by creating a file named "state.lock" with O_EXCL.
+// If the lock is already held, it waits up to ~2s with jitter and retries.
+// On success it returns an unlock function that removes the lock file.
+// If the lock cannot be acquired within the wait budget, it returns a no-op
+// unlock function and nil error so callers can proceed without crashing.
+func acquireStateLock(dir string) (func(), error) {
+	lockPath := filepath.Join(dir, "state.lock")
+
+	// Ensure directory exists so we can create the lock file.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return func() {}, err
+	}
+	// Best-effort set exact perms (in case existing dir had broader perms).
+	if err := os.Chmod(dir, 0o700); err != nil {
+		// ignore; directory may already have stricter perms
+		_ = err
+	}
+
+	tryOnce := func() (bool, error) {
+		// Include a small token in the file for debugging; best-effort.
+		var token [8]byte
+		if _, err := rand.Read(token[:]); err != nil {
+			// ignore; token will be zeroed which is fine for debug content
+			_ = err
+		}
+		contents := []byte(fmt.Sprintf("ts=%s token=%s\n", time.Now().UTC().Format(time.RFC3339Nano), hex.EncodeToString(token[:])))
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err != nil {
+			if os.IsExist(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		if _, werr := f.Write(contents); werr != nil {
+			_ = f.Close()           //nolint:errcheck // best-effort cleanup on error
+			_ = os.Remove(lockPath) //nolint:errcheck // best-effort cleanup on error
+			return false, werr
+		}
+		if serr := f.Sync(); serr != nil {
+			_ = f.Close()           //nolint:errcheck // best-effort cleanup on error
+			_ = os.Remove(lockPath) //nolint:errcheck // best-effort cleanup on error
+			return false, serr
+		}
+		if cerr := f.Close(); cerr != nil {
+			_ = os.Remove(lockPath) //nolint:errcheck // best-effort cleanup on error
+			return false, cerr
+		}
+		return true, nil
+	}
+
+	// Immediate attempt
+	ok, err := tryOnce()
+	if err != nil {
+		return func() {}, err
+	}
+	if ok {
+		return func() {
+			if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
+				_ = err
+			}
+		}, nil
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		// Sleep 50-150ms jitter
+		sleep := 50 + int(time.Now().UnixNano()%100)
+		time.Sleep(time.Duration(sleep) * time.Millisecond)
+		ok, err := tryOnce()
+		if err != nil {
+			return func() {}, err
+		}
+		if ok {
+			return func() {
+				if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
+					_ = err
+				}
+			}, nil
+		}
+	}
+	// Failed to acquire; proceed without lock
+	return func() {}, nil
+}

--- a/internal/state/save.go
+++ b/internal/state/save.go
@@ -1,0 +1,171 @@
+package state
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// latestPointer is the JSON structure written to latest.json to point to the
+// concrete snapshot file. The path is the base name inside the state directory.
+type latestPointer struct {
+	Version string `json:"version"`
+	Path    string `json:"path"`
+	SHA256  string `json:"sha256"`
+}
+
+// syncDirFunc is a hook to fsync a directory after atomic renames.
+// It is a var so tests can override and assert that directory fsync was used.
+var syncDirFunc = func(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := d.Close(); cerr != nil {
+			// best-effort: ignore close error for directory sync
+			_ = cerr
+		}
+	}()
+	return d.Sync()
+}
+
+// writeFileAtomic writes data to a temporary file next to dstPath with mode 0600,
+// fsyncs the file, renames it atomically to dstPath, and fsyncs the directory.
+func writeFileAtomic(dir string, dstPath string, data []byte) error {
+	// Ensure directory exists with 0700 perms
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	// Best-effort set exact perms (in case existing dir had broader perms)
+	if err := os.Chmod(dir, 0o700); err != nil {
+		// best-effort: directory may already have stricter perms
+		_ = err
+	}
+
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	// Ensure 0600 permissions for the temp file
+	if err := tmp.Chmod(0o600); err != nil {
+		if cerr := tmp.Close(); cerr != nil {
+			_ = cerr
+		}
+		if rerr := os.Remove(tmpName); rerr != nil {
+			_ = rerr
+		}
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		if cerr := tmp.Close(); cerr != nil {
+			_ = cerr
+		}
+		if rerr := os.Remove(tmpName); rerr != nil {
+			_ = rerr
+		}
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		if cerr := tmp.Close(); cerr != nil {
+			_ = cerr
+		}
+		if rerr := os.Remove(tmpName); rerr != nil {
+			_ = rerr
+		}
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		if rerr := os.Remove(tmpName); rerr != nil {
+			_ = rerr
+		}
+		return err
+	}
+	if err := os.Rename(tmpName, dstPath); err != nil {
+		if rerr := os.Remove(tmpName); rerr != nil {
+			_ = rerr
+		}
+		return err
+	}
+	if err := syncDirFunc(dir); err != nil {
+		return err
+	}
+	return nil
+}
+
+// sanitizeRFC3339ForFilename makes the RFC3339 timestamp safe for cross-platform filenames
+// by removing ':' characters. Example: 2006-01-02T15:04:05Z07:00 -> 2006-01-02T150405Z0700
+func sanitizeRFC3339ForFilename(ts string) string {
+	// Remove colons which are problematic on Windows filesystems
+	return strings.ReplaceAll(ts, ":", "")
+}
+
+// SaveStateBundle persists the provided bundle into dir using an atomic write strategy.
+// It writes a content-addressed snapshot file named
+//
+//	state-<RFC3339UTC>-<8charSHA>.json
+//
+// and then updates latest.json atomically to point to that snapshot. All files are
+// written with 0600 permissions and the directory is fsync'ed after renames.
+// The function does not mutate the given bundle; callers must ensure it is valid.
+func SaveStateBundle(dir string, bundle *StateBundle) error {
+	if bundle == nil {
+		return errors.New("nil bundle")
+	}
+	if err := bundle.Validate(); err != nil {
+		return fmt.Errorf("invalid bundle: %w", err)
+	}
+
+	// Security: reject insecure directories (world-writable or non-owned) on Unix
+	if err := ensureSecureStateDir(dir); err != nil {
+		return err
+	}
+
+	// Attempt coarse-grained advisory lock to avoid concurrent writes
+	if unlock, lockErr := acquireStateLock(dir); lockErr == nil && unlock != nil {
+		defer unlock()
+	}
+
+	// Redact/sanitize secrets before persisting
+	sanitized, err := sanitizeBundleForSave(bundle)
+	if err != nil {
+		return err
+	}
+
+	// Marshal the snapshot deterministically.
+	// Note: json.Marshal is sufficient; map key ordering is not relied upon for correctness here.
+	snapshotBytes, err := json.MarshalIndent(sanitized, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	// Compute content hash for integrity and short suffix
+	sum := sha256.Sum256(snapshotBytes)
+	shaHex := hex.EncodeToString(sum[:])
+	short8 := shaHex[:8]
+
+	baseName := fmt.Sprintf("state-%s-%s.json", sanitizeRFC3339ForFilename(bundle.CreatedAt), short8)
+	finalPath := filepath.Join(dir, baseName)
+
+	if err := writeFileAtomic(dir, finalPath, snapshotBytes); err != nil {
+		return err
+	}
+
+	// Write pointer file
+	ptr := latestPointer{Version: "1", Path: baseName, SHA256: shaHex}
+	ptrBytes, err := json.MarshalIndent(ptr, "", "  ")
+	if err != nil {
+		return err
+	}
+	latestPath := filepath.Join(dir, "latest.json")
+	if err := writeFileAtomic(dir, latestPath, ptrBytes); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/state/save_test.go
+++ b/internal/state/save_test.go
@@ -1,0 +1,263 @@
+package state
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSaveStateBundle_WritesFilesAtomicallyWithPermsAndPointer(t *testing.T) {
+	// Arrange
+	tempDir := t.TempDir()
+
+	// Track whether syncDirFunc was called
+	calledSync := false
+	syncDirFunc = func(dir string) error {
+		calledSync = true
+		f, err := os.Open(dir)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := f.Close(); err != nil {
+				t.Logf("ignored close error: %v", err)
+			}
+		}()
+		return f.Sync()
+	}
+	t.Cleanup(func() {
+		syncDirFunc = func(dir string) error {
+			f, err := os.Open(dir)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := f.Close(); err != nil {
+					t.Logf("ignored close error: %v", err)
+				}
+			}()
+			return f.Sync()
+		}
+	})
+
+	now := time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
+	b := &StateBundle{
+		Version:     "1",
+		CreatedAt:   now,
+		ToolVersion: "test-1",
+		ModelID:     "gpt-5",
+		BaseURL:     "http://example.local",
+		ToolsetHash: "abc",
+		ScopeKey:    "scope-1",
+		Prompts:     map[string]string{"system": "hi"},
+		SourceHash:  ComputeSourceHash("gpt-5", "http://example.local", "abc", "scope-1"),
+	}
+
+	// Act
+	if err := SaveStateBundle(tempDir, b); err != nil {
+		t.Fatalf("SaveStateBundle error: %v", err)
+	}
+
+	// Assert snapshot exists
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var snapshot string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "state-") && strings.HasSuffix(e.Name(), ".json") {
+			snapshot = e.Name()
+			break
+		}
+	}
+	if snapshot == "" {
+		t.Fatalf("snapshot file not found in %s", tempDir)
+	}
+
+	// Check file mode 0600
+	info, err := os.Stat(filepath.Join(tempDir, snapshot))
+	if err != nil {
+		t.Fatalf("stat snapshot: %v", err)
+	}
+	if runtime.GOOS != "windows" { // Windows has different mode semantics
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("snapshot perms = %v, want 0600", info.Mode().Perm())
+		}
+	}
+
+	// Check latest.json exists and points to snapshot
+	latestPath := filepath.Join(tempDir, "latest.json")
+	latestBytes, err := os.ReadFile(latestPath)
+	if err != nil {
+		t.Fatalf("read latest.json: %v", err)
+	}
+	var ptr latestPointer
+	if err := json.Unmarshal(latestBytes, &ptr); err != nil {
+		t.Fatalf("unmarshal latest.json: %v", err)
+	}
+	if ptr.Version != "1" {
+		t.Fatalf("pointer version = %q, want 1", ptr.Version)
+	}
+	if ptr.Path != snapshot {
+		t.Fatalf("pointer path = %q, want %q", ptr.Path, snapshot)
+	}
+	if ptr.SHA256 == "" {
+		t.Fatalf("pointer sha256 empty")
+	}
+
+	if !calledSync {
+		t.Fatalf("expected directory fsync to be called")
+	}
+}
+
+func TestSaveStateBundle_AdvisoryLock_AllowsSingleWriter(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	now := time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
+	mk := func(i int) *StateBundle {
+		return &StateBundle{
+			Version:     "1",
+			CreatedAt:   now,
+			ToolVersion: "test-1",
+			ModelID:     "gpt-5",
+			BaseURL:     "http://example.local",
+			ToolsetHash: "abc",
+			ScopeKey:    "scope-1",
+			Prompts:     map[string]string{"system": "hi"},
+			SourceHash:  ComputeSourceHash("gpt-5", "http://example.local", "abc", "scope-1"),
+		}
+	}
+
+	done := make(chan error, 2)
+	go func() { done <- SaveStateBundle(dir, mk(1)) }()
+	go func() { done <- SaveStateBundle(dir, mk(2)) }()
+
+	// Both should succeed; lock serializes them. Wait for both.
+	if err := <-done; err != nil {
+		t.Fatalf("first SaveStateBundle error: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("second SaveStateBundle error: %v", err)
+	}
+
+	// There must be exactly one latest.json and at least one snapshot.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	hasLatest := false
+	snapCount := 0
+	hasTmp := false
+	for _, e := range entries {
+		switch {
+		case e.Name() == "latest.json":
+			hasLatest = true
+		case strings.HasPrefix(e.Name(), "state-") && strings.HasSuffix(e.Name(), ".json"):
+			snapCount++
+		case strings.HasPrefix(e.Name(), ".tmp-"):
+			hasTmp = true
+		}
+	}
+	if !hasLatest {
+		t.Fatalf("missing latest.json after concurrent writes")
+	}
+	if snapCount == 0 {
+		t.Fatalf("no snapshot files after concurrent writes")
+	}
+	if hasTmp {
+		t.Fatalf("found lingering temp files after concurrent writes")
+	}
+
+	// Pointer should load successfully
+	if b, err := LoadLatestStateBundle(dir); err != nil || b == nil {
+		t.Fatalf("LoadLatestStateBundle failed after concurrent writes: %v, %v", err, b)
+	}
+}
+
+func TestSaveStateBundle_InvalidBundle(t *testing.T) {
+	tempDir := t.TempDir()
+	// Missing required fields (CreatedAt invalid)
+	b := &StateBundle{Version: "1", CreatedAt: "not-time", ModelID: "m", BaseURL: "u", ScopeKey: "s"}
+	if err := SaveStateBundle(tempDir, b); err == nil {
+		t.Fatalf("expected error for invalid bundle")
+	}
+}
+
+func TestSaveStateBundle_SanitizesSecretsAndRejectsInsecureDir(t *testing.T) {
+	tempDir := t.TempDir()
+	// Make directory world-writable on Unix to trigger rejection; skip on Windows
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(tempDir, 0o707); err != nil {
+			t.Fatalf("chmod: %v", err)
+		}
+	}
+
+	now := time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
+	b := &StateBundle{
+		Version:     "1",
+		CreatedAt:   now,
+		ToolVersion: "test-1",
+		ModelID:     "gpt-5",
+		BaseURL:     "http://example.local",
+		ToolsetHash: "abc",
+		ScopeKey:    "scope-1",
+		Prompts:     map[string]string{"system": "Authorization: Bearer secretTOKEN1234567890"},
+		PrepSettings: map[string]any{
+			"api_key":      "sk-verylongexamplekey-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+			"request_body": "{ big raw body }",
+		},
+		SourceHash: ComputeSourceHash("gpt-5", "http://example.local", "abc", "scope-1"),
+	}
+
+	err := SaveStateBundle(tempDir, b)
+	if runtime.GOOS != "windows" {
+		if err == nil {
+			t.Fatalf("expected error for insecure dir perms")
+		}
+		// Fix perms and try again
+		if err := os.Chmod(tempDir, 0o700); err != nil {
+			t.Fatalf("chmod fix: %v", err)
+		}
+	}
+
+	if err := SaveStateBundle(tempDir, b); err != nil {
+		t.Fatalf("SaveStateBundle error after fix: %v", err)
+	}
+	// Read snapshot and verify redactions present
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var snapshot string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "state-") && strings.HasSuffix(e.Name(), ".json") {
+			snapshot = filepath.Join(tempDir, e.Name())
+			break
+		}
+	}
+	if snapshot == "" {
+		t.Fatalf("snapshot not found")
+	}
+	data, err := os.ReadFile(snapshot)
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, "secretTOKEN1234567890") {
+		t.Fatalf("authorization token not redacted: %s", s)
+	}
+	if !strings.Contains(s, "Authorization: Bearer ****") {
+		t.Fatalf("authorization scheme not preserved/redacted: %s", s)
+	}
+	if strings.Contains(s, "sk-verylongexamplekey") {
+		t.Fatalf("api key not redacted: %s", s)
+	}
+	if strings.Contains(s, "{ big raw body }") {
+		t.Fatalf("raw body not omitted: %s", s)
+	}
+}

--- a/internal/state/schema.go
+++ b/internal/state/schema.go
@@ -1,0 +1,73 @@
+package state
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// StateBundle is the versioned persisted execution state snapshot.
+// Only JSON-serializable fields; do not include runtime-only data.
+// Version must be "1" for the initial schema.
+// All timestamps are RFC3339 with UTC timezone.
+// Files must be written with permissions 0600.
+// The pointer file latest.json must contain a JSON object pointing to a concrete snapshot path.
+
+type StateBundle struct {
+	Version      string            `json:"version"`
+	CreatedAt    string            `json:"created_at"`
+	ToolVersion  string            `json:"tool_version"`
+	ModelID      string            `json:"model_id"`
+	BaseURL      string            `json:"base_url"`
+	ToolsetHash  string            `json:"toolset_hash"`
+	ScopeKey     string            `json:"scope_key"`
+	Prompts      map[string]string `json:"prompts"`
+	PrepSettings map[string]any    `json:"prep_settings"`
+	Context      map[string]any    `json:"context"`
+	ToolCaps     map[string]any    `json:"tool_caps"`
+	Custom       map[string]any    `json:"custom"`
+	SourceHash   string            `json:"source_hash"`
+	PrevSHA      string            `json:"prev_sha,omitempty"`
+}
+
+var (
+	errInvalidVersion   = errors.New("invalid version")
+	errMissingTimestamp = errors.New("invalid created_at")
+	errMissingModel     = errors.New("missing model_id")
+	errMissingBaseURL   = errors.New("missing base_url")
+	errMissingScope     = errors.New("missing scope_key")
+)
+
+// Validate returns nil if the bundle is structurally valid for version 1.
+func (b *StateBundle) Validate() error {
+	if b == nil {
+		return errors.New("nil bundle")
+	}
+	if b.Version != "1" {
+		return fmt.Errorf("%w: %s", errInvalidVersion, b.Version)
+	}
+	if _, err := time.Parse(time.RFC3339, b.CreatedAt); err != nil {
+		return errMissingTimestamp
+	}
+	if b.ModelID == "" {
+		return errMissingModel
+	}
+	if b.BaseURL == "" {
+		return errMissingBaseURL
+	}
+	if b.ScopeKey == "" {
+		return errMissingScope
+	}
+	// Optional maps may be nil; normalize callers should handle nil.
+	return nil
+}
+
+// ComputeSourceHash returns a hex-encoded SHA-256 of select identifying fields.
+// This is used to detect changes across runs; callers decide the exact input.
+func ComputeSourceHash(modelID string, baseURL string, toolsetHash string, scopeKey string) string {
+	input := modelID + "|" + baseURL + "|" + toolsetHash + "|" + scopeKey
+	sum := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/state/schema_test.go
+++ b/internal/state/schema_test.go
@@ -1,0 +1,52 @@
+package state
+
+import (
+	"testing"
+)
+
+func TestValidate_OK(t *testing.T) {
+	b := &StateBundle{
+		Version:     "1",
+		CreatedAt:   "2025-08-19T00:00:00Z",
+		ToolVersion: "dev",
+		ModelID:     "gpt-5",
+		BaseURL:     "https://api.openai.example/v1",
+		ToolsetHash: "abc123",
+		ScopeKey:    "scope",
+		Prompts:     map[string]string{"system": "s"},
+		SourceHash:  "deadbeef",
+	}
+	if err := b.Validate(); err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+}
+
+func TestValidate_Errors(t *testing.T) {
+	cases := []struct {
+		name string
+		b    StateBundle
+	}{
+		{"bad version", StateBundle{Version: "2", CreatedAt: "2025-08-19T00:00:00Z", ModelID: "m", BaseURL: "u", ScopeKey: "s"}},
+		{"bad ts", StateBundle{Version: "1", CreatedAt: "not-time", ModelID: "m", BaseURL: "u", ScopeKey: "s"}},
+		{"no model", StateBundle{Version: "1", CreatedAt: "2025-08-19T00:00:00Z", BaseURL: "u", ScopeKey: "s"}},
+		{"no base", StateBundle{Version: "1", CreatedAt: "2025-08-19T00:00:00Z", ModelID: "m", ScopeKey: "s"}},
+		{"no scope", StateBundle{Version: "1", CreatedAt: "2025-08-19T00:00:00Z", ModelID: "m", BaseURL: "u"}},
+	}
+	for _, tc := range cases {
+		if err := tc.b.Validate(); err == nil {
+			t.Fatalf("%s: expected error", tc.name)
+		}
+	}
+}
+
+func TestComputeSourceHash_Deterministic(t *testing.T) {
+	got1 := ComputeSourceHash("m", "u", "t", "s")
+	got2 := ComputeSourceHash("m", "u", "t", "s")
+	if got1 != got2 {
+		t.Fatalf("hash not deterministic: %s vs %s", got1, got2)
+	}
+	got3 := ComputeSourceHash("m2", "u", "t", "s")
+	if got1 == got3 {
+		t.Fatalf("hash should change on input change")
+	}
+}

--- a/internal/state/security.go
+++ b/internal/state/security.go
@@ -1,0 +1,194 @@
+package state
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
+	"syscall"
+)
+
+// ensureSecureStateDir validates the state directory on Unix-like systems.
+// It rejects world-writable or non-owned directories to avoid leaking secrets.
+// On non-Unix platforms (e.g., Windows), the checks are skipped.
+func ensureSecureStateDir(dir string) error {
+	if strings.TrimSpace(dir) == "" {
+		return errors.New("empty state dir")
+	}
+	// Only enforce on Unix-like systems. Windows ACLs differ and Mode().Perm() is not authoritative.
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		// If it doesn't exist yet, the caller will create with 0700; allow.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return errors.New("state dir is not a directory")
+	}
+
+	// Reject world-writable (others write bit set)
+	if info.Mode().Perm()&0o002 != 0 {
+		return errors.New("state dir is world-writable")
+	}
+
+	// Reject if not owned by current user (best-effort; skip if not supported)
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		uid := uint32(os.Getuid())
+		if stat.Uid != uid {
+			return errors.New("state dir is not owned by current user")
+		}
+	}
+	return nil
+}
+
+// sanitizeBundleForSave returns a deep-copied and redacted bundle suitable for persistence.
+// It avoids storing obvious secrets and raw bodies by:
+//   - masking any values under keys containing "api_key", "apikey", "token", "authorization", "password", "secret"
+//   - stripping Authorization header values (preserving scheme)
+//   - removing long base64-like tokens (>=64 chars) within strings
+//   - omitting likely raw request/response bodies under keys: request_body, response_body, raw_request, raw_response
+func sanitizeBundleForSave(b *StateBundle) (*StateBundle, error) {
+	if b == nil {
+		return nil, errors.New("nil bundle")
+	}
+
+	// Shallow copy value fields and deep-copy maps
+	out := &StateBundle{
+		Version:     b.Version,
+		CreatedAt:   b.CreatedAt,
+		ToolVersion: b.ToolVersion,
+		ModelID:     b.ModelID,
+		BaseURL:     b.BaseURL,
+		ToolsetHash: b.ToolsetHash,
+		ScopeKey:    b.ScopeKey,
+		SourceHash:  b.SourceHash,
+		PrevSHA:     b.PrevSHA,
+	}
+
+	// Copy and sanitize string map
+	if b.Prompts != nil {
+		out.Prompts = make(map[string]string, len(b.Prompts))
+		for k, v := range b.Prompts {
+			out.Prompts[k] = sanitizeStringByHeuristics(k, v)
+		}
+	}
+	// Copy and sanitize any maps
+	out.PrepSettings = sanitizeAnyMap(b.PrepSettings)
+	out.Context = sanitizeAnyMap(b.Context)
+	out.ToolCaps = sanitizeAnyMap(b.ToolCaps)
+	out.Custom = sanitizeAnyMap(b.Custom)
+
+	// Validate round-trip JSON to ensure serializable
+	if _, err := json.Marshal(out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func sanitizeAnyMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = sanitizeValue(k, v)
+	}
+	return out
+}
+
+func sanitizeAnySlice(key string, in []any) []any {
+	if in == nil {
+		return nil
+	}
+	out := make([]any, 0, len(in))
+	for _, v := range in {
+		out = append(out, sanitizeValue(key, v))
+	}
+	return out
+}
+
+var (
+	// Detect long base64-like tokens (64+ chars of base64 charset)
+	reLongB64 = regexp.MustCompile(`[A-Za-z0-9+/=]{64,}`)
+	// Detect Authorization header anywhere in the string, case-insensitive
+	reAuthAny = regexp.MustCompile(`(?i)authorization\s*:\s*(bearer|token|basic)\s+([A-Za-z0-9._\-]+)`) // keep scheme, mask token
+)
+
+func sanitizeValue(key string, v any) any {
+	switch t := v.(type) {
+	case string:
+		lowerKey := strings.ToLower(key)
+		// Omit likely raw bodies entirely
+		if lowerKey == "request_body" || lowerKey == "response_body" || lowerKey == "raw_request" || lowerKey == "raw_response" {
+			return "<omitted>"
+		}
+		return sanitizeStringByHeuristics(key, t)
+	case map[string]any:
+		return sanitizeAnyMap(t)
+	case []any:
+		return sanitizeAnySlice(key, t)
+	default:
+		// Leave numbers, bools, nil as-is
+		return v
+	}
+}
+
+func sanitizeStringByHeuristics(key string, s string) string {
+	v := s
+	lowerKey := strings.ToLower(key)
+	// Redact inline Authorization headers regardless of key name
+	v = reAuthAny.ReplaceAllStringFunc(v, func(match string) string {
+		m := reAuthAny.FindStringSubmatch(match)
+		if len(m) >= 3 {
+			scheme := m[1]
+			token := m[2]
+			return "Authorization: " + scheme + " ****" + last4(token)
+		}
+		return "Authorization: <redacted>"
+	})
+	if containsAny(lowerKey, []string{"api_key", "apikey", "token", "password", "secret"}) {
+		vv := strings.TrimSpace(v)
+		if vv == "" {
+			v = ""
+		} else if len(vv) <= 4 {
+			v = "****" + vv
+		} else {
+			v = "****" + vv[len(vv)-4:]
+		}
+	}
+	// Redact long base64-like runs
+	if reLongB64.MatchString(v) {
+		v = reLongB64.ReplaceAllStringFunc(v, func(match string) string {
+			if len(match) <= 4 {
+				return "****" + match
+			}
+			return "****" + match[len(match)-4:]
+		})
+	}
+	return v
+}
+
+func containsAny(s string, needles []string) bool {
+	for _, n := range needles {
+		if strings.Contains(s, n) {
+			return true
+		}
+	}
+	return false
+}
+
+func last4(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= 4 {
+		return s
+	}
+	return s[len(s)-4:]
+}


### PR DESCRIPTION
## Scope
- Adds atomic snapshot save with fsync and latest.json pointer
- Implements load with integrity checks and quarantine
- Introduces coarse advisory lock and secure dir validation

## Why
- Reliable, secure persistence for state bundle

## Testing
- Focused: === RUN   TestLoadLatestStateBundle_OK
--- PASS: TestLoadLatestStateBundle_OK (0.02s)
=== RUN   TestLoadLatestStateBundle_RejectsInsecureDir
--- PASS: TestLoadLatestStateBundle_RejectsInsecureDir (0.01s)
=== RUN   TestLoadLatestStateBundle_MissingLatest
--- PASS: TestLoadLatestStateBundle_MissingLatest (0.00s)
=== RUN   TestLoadLatestStateBundle_CorruptLatest
--- PASS: TestLoadLatestStateBundle_CorruptLatest (0.00s)
=== RUN   TestLoadLatestStateBundle_UnknownVersion
--- PASS: TestLoadLatestStateBundle_UnknownVersion (0.02s)
=== RUN   TestLoadLatestStateBundle_MissingSnapshot
--- PASS: TestLoadLatestStateBundle_MissingSnapshot (0.00s)
=== RUN   TestLoadLatestStateBundle_PermissionDenied
--- PASS: TestLoadLatestStateBundle_PermissionDenied (0.01s)
=== RUN   TestLoadLatestStateBundle_SnapshotHashMismatch_QuarantineBoth
--- PASS: TestLoadLatestStateBundle_SnapshotHashMismatch_QuarantineBoth (0.02s)
=== RUN   TestLoadLatestStateBundle_CorruptSnapshotJSON_QuarantineBoth
--- PASS: TestLoadLatestStateBundle_CorruptSnapshotJSON_QuarantineBoth (0.01s)
=== RUN   TestSaveStateBundle_WritesFilesAtomicallyWithPermsAndPointer
--- PASS: TestSaveStateBundle_WritesFilesAtomicallyWithPermsAndPointer (0.02s)
=== RUN   TestSaveStateBundle_AdvisoryLock_AllowsSingleWriter
=== PAUSE TestSaveStateBundle_AdvisoryLock_AllowsSingleWriter
=== RUN   TestSaveStateBundle_InvalidBundle
--- PASS: TestSaveStateBundle_InvalidBundle (0.00s)
=== RUN   TestSaveStateBundle_SanitizesSecretsAndRejectsInsecureDir
--- PASS: TestSaveStateBundle_SanitizesSecretsAndRejectsInsecureDir (0.01s)
=== CONT  TestSaveStateBundle_AdvisoryLock_AllowsSingleWriter
--- PASS: TestSaveStateBundle_AdvisoryLock_AllowsSingleWriter (0.11s)
PASS
ok  	github.com/hyperifyio/goagent/internal/state	0.265s

## Relation
- Builds upon PR #50 (state schema)

## Tracking
- Will record under  and  on develop.
