### PR TITLE
Sandbox: limits utilities (bounded buffer, wall timeout, JSON error)

### DIFF
--- a/internal/sandbox/limits.go
+++ b/internal/sandbox/limits.go
@@ -1,0 +1,80 @@
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrOutputLimit is returned when a bounded writer exceeds its configured cap.
+var ErrOutputLimit = errors.New("OUTPUT_LIMIT")
+
+// ErrTimeout is returned by helpers when execution exceeds the wall-time budget.
+var ErrTimeout = errors.New("TIMEOUT")
+
+// BoundedBuffer is an io.Writer implementation that caps total bytes written.
+// When the cap is exceeded, it truncates additional input and returns ErrOutputLimit.
+// Use Bytes() or String() to retrieve accumulated output and Truncated() to check status.
+//
+// Note: The writer never grows beyond the configured capacity in memory.
+// A zero or negative maxKB defaults to 64 KiB.
+type BoundedBuffer struct {
+	buf       bytes.Buffer
+	capBytes  int
+	truncated bool
+}
+
+// NewBoundedBuffer creates a new BoundedBuffer with the provided maxKB capacity.
+func NewBoundedBuffer(maxKB int) *BoundedBuffer {
+	if maxKB <= 0 {
+		maxKB = 64
+	}
+	return &BoundedBuffer{capBytes: maxKB * 1024}
+}
+
+// Write appends p to the buffer up to the capacity. If the write causes
+// the capacity to be exceeded, the write is truncated and ErrOutputLimit is returned.
+func (b *BoundedBuffer) Write(p []byte) (int, error) {
+	if b.capBytes <= 0 {
+		return 0, ErrOutputLimit
+	}
+	remaining := b.capBytes - b.buf.Len()
+	if remaining <= 0 {
+		b.truncated = true
+		return 0, ErrOutputLimit
+	}
+	if len(p) > remaining {
+		// Partial write up to remaining capacity
+		_, _ = b.buf.Write(p[:remaining])
+		b.truncated = true
+		return remaining, ErrOutputLimit
+	}
+	return b.buf.Write(p)
+}
+
+// Bytes returns the current contents (may be truncated if cap exceeded).
+func (b *BoundedBuffer) Bytes() []byte { return b.buf.Bytes() }
+
+// String returns the current contents as string (may be truncated).
+func (b *BoundedBuffer) String() string { return b.buf.String() }
+
+// Truncated reports whether any write exceeded the cap.
+func (b *BoundedBuffer) Truncated() bool { return b.truncated }
+
+// WithWallTimeout returns a derived context that is canceled after wallMS milliseconds.
+// If wallMS <= 0, a conservative default of 1000ms is used.
+func WithWallTimeout(parent context.Context, wallMS int) (context.Context, context.CancelFunc) {
+	if wallMS <= 0 {
+		wallMS = 1000
+	}
+	return context.WithTimeout(parent, time.Duration(wallMS)*time.Millisecond)
+}
+
+// JSONError is a tiny helper to construct a standard error payload shape.
+// Callers generally write this to stderr.
+func JSONError(code, message string) []byte {
+	// Minimal hand-rolled JSON to avoid allocations and error paths here.
+	// code and message are expected to be short ASCII; if not, JSON remains valid but unescaped.
+	return []byte(`{"code":"` + code + `","message":"` + message + `"}`)
+}

--- a/internal/sandbox/limits_test.go
+++ b/internal/sandbox/limits_test.go
@@ -1,0 +1,59 @@
+package sandbox
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBoundedBuffer_TruncatesAndSignals(t *testing.T) {
+	buf := NewBoundedBuffer(1) // 1 KiB
+	payload := strings.Repeat("A", 1536)
+	n, err := buf.Write([]byte(payload))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if err != ErrOutputLimit {
+		t.Fatalf("expected ErrOutputLimit, got %v", err)
+	}
+	if n != 1024 {
+		t.Fatalf("expected partial write of 1024, got %d", n)
+	}
+	if !buf.Truncated() {
+		t.Fatalf("expected truncated=true")
+	}
+	if len(buf.Bytes()) != 1024 {
+		t.Fatalf("expected buffer length 1024, got %d", len(buf.Bytes()))
+	}
+}
+
+func TestBoundedBuffer_FitsWithinCap(t *testing.T) {
+	buf := NewBoundedBuffer(2) // 2 KiB
+	payload := strings.Repeat("B", 1500)
+	n, err := buf.Write([]byte(payload))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1500 {
+		t.Fatalf("expected full write of 1500, got %d", n)
+	}
+	if buf.Truncated() {
+		t.Fatalf("did not expect truncation")
+	}
+	if len(buf.Bytes()) != 1500 {
+		t.Fatalf("expected buffer length 1500, got %d", len(buf.Bytes()))
+	}
+}
+
+func TestWithWallTimeout_TimesOutRoughlyOnBudget(t *testing.T) {
+	ctx, cancel := WithWallTimeout(context.Background(), 50)
+	defer cancel()
+
+	start := time.Now()
+	<-ctx.Done()
+	elapsed := time.Since(start)
+	if elapsed < 40*time.Millisecond || elapsed > 250*time.Millisecond {
+		t.Fatalf("expected ~50ms timeout, got %v", elapsed)
+	}
+}


### PR DESCRIPTION
Adds `internal/sandbox/limits.go` and tests providing:\n- bounded output buffer with truncation signal\n- wall-time context helper\n- minimal JSON error helper\n\nIndependent slice to support future js/wasm runners and tighter tool guards.\n\nTracks: FEATURE_CHECKLIST.md — Sandbox: limits utilities.