### PR TITLE
Sandbox: WebAssembly runner (validation + memory bounds)

### DIFF
--- a/internal/tools/wasmrun/handler.go
+++ b/internal/tools/wasmrun/handler.go
@@ -1,0 +1,215 @@
+package wasmrun
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Input models the expected stdin JSON for code.sandbox.wasm.run
+type Input struct {
+	ModuleB64 string `json:"module_b64"`
+	Entry     string `json:"entry"`
+	Input     string `json:"input"`
+	Limits    struct {
+		WallMS   int `json:"wall_ms"`
+		MemPages int `json:"mem_pages"`
+		OutputKB int `json:"output_kb"`
+	} `json:"limits"`
+}
+
+// Output is the successful stdout JSON shape
+type Output struct {
+	Output string `json:"output"`
+}
+
+// Error represents a structured error payload for stderr JSON
+type Error struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+var (
+	errInvalidInput = errors.New("INVALID_INPUT")
+)
+
+// Run parses input and (in future) executes the provided WebAssembly module.
+// Returns (stdoutJSON, stderrJSON, err). For now, only input validation is implemented.
+func Run(raw []byte) ([]byte, []byte, error) {
+	start := time.Now()
+	var in Input
+	if err := json.Unmarshal(raw, &in); err != nil {
+		// audit invalid input
+		_ = appendAudit(map[string]any{ //nolint:errcheck // best-effort audit
+			"ts":             time.Now().UTC().Format(time.RFC3339Nano),
+			"tool":           "code.sandbox.wasm.run",
+			"span":           "tools.wasm.run",
+			"ms":             time.Since(start).Milliseconds(),
+			"module_bytes":   0,
+			"wall_ms":        0,
+			"mem_pages_used": 0,
+			"bytes_out":      0,
+			"event":          "INVALID_INPUT",
+		})
+		return nil, mustMarshalError("INVALID_INPUT", "invalid JSON: "+err.Error()), errInvalidInput
+	}
+	if in.ModuleB64 == "" {
+		_ = appendAudit(map[string]any{ //nolint:errcheck // best-effort audit
+			"ts":             time.Now().UTC().Format(time.RFC3339Nano),
+			"tool":           "code.sandbox.wasm.run",
+			"span":           "tools.wasm.run",
+			"ms":             time.Since(start).Milliseconds(),
+			"module_bytes":   0,
+			"wall_ms":        in.Limits.WallMS,
+			"mem_pages_used": 0,
+			"bytes_out":      0,
+			"event":          "INVALID_INPUT",
+		})
+		return nil, mustMarshalError("INVALID_INPUT", "missing module_b64"), errInvalidInput
+	}
+	// Validate base64 early to surface errors deterministically
+	modBytes, err := base64.StdEncoding.DecodeString(in.ModuleB64)
+	if err != nil {
+		_ = appendAudit(map[string]any{ //nolint:errcheck // best-effort audit
+			"ts":             time.Now().UTC().Format(time.RFC3339Nano),
+			"tool":           "code.sandbox.wasm.run",
+			"span":           "tools.wasm.run",
+			"ms":             time.Since(start).Milliseconds(),
+			"module_bytes":   0,
+			"wall_ms":        in.Limits.WallMS,
+			"mem_pages_used": 0,
+			"bytes_out":      0,
+			"event":          "INVALID_INPUT",
+		})
+		return nil, mustMarshalError("INVALID_INPUT", "module_b64 is not valid base64: "+err.Error()), errInvalidInput
+	}
+	// Validate limits
+	if in.Limits.OutputKB <= 0 {
+		_ = appendAudit(map[string]any{ //nolint:errcheck // best-effort audit
+			"ts":             time.Now().UTC().Format(time.RFC3339Nano),
+			"tool":           "code.sandbox.wasm.run",
+			"span":           "tools.wasm.run",
+			"ms":             time.Since(start).Milliseconds(),
+			"module_bytes":   len(modBytes),
+			"wall_ms":        in.Limits.WallMS,
+			"mem_pages_used": 0,
+			"bytes_out":      0,
+			"event":          "INVALID_INPUT",
+		})
+		return nil, mustMarshalError("INVALID_INPUT", "limits.output_kb must be > 0"), errInvalidInput
+	}
+	if in.Limits.WallMS <= 0 {
+		_ = appendAudit(map[string]any{ //nolint:errcheck // best-effort audit
+			"ts":             time.Now().UTC().Format(time.RFC3339Nano),
+			"tool":           "code.sandbox.wasm.run",
+			"span":           "tools.wasm.run",
+			"ms":             time.Since(start).Milliseconds(),
+			"module_bytes":   len(modBytes),
+			"wall_ms":        in.Limits.WallMS,
+			"mem_pages_used": 0,
+			"bytes_out":      0,
+			"event":          "INVALID_INPUT",
+		})
+		return nil, mustMarshalError("INVALID_INPUT", "limits.wall_ms must be > 0"), errInvalidInput
+	}
+	if in.Limits.MemPages <= 0 {
+		_ = appendAudit(map[string]any{ //nolint:errcheck // best-effort audit
+			"ts":             time.Now().UTC().Format(time.RFC3339Nano),
+			"tool":           "code.sandbox.wasm.run",
+			"span":           "tools.wasm.run",
+			"ms":             time.Since(start).Milliseconds(),
+			"module_bytes":   len(modBytes),
+			"wall_ms":        in.Limits.WallMS,
+			"mem_pages_used": 0,
+			"bytes_out":      0,
+			"event":          "INVALID_INPUT",
+		})
+		return nil, mustMarshalError("INVALID_INPUT", "limits.mem_pages must be > 0"), errInvalidInput
+	}
+
+	// Deny WASI by default: detect imports of wasi_snapshot_preview1 and fail fast.
+	// This is a conservative check prior to implementing full wasm execution.
+	if bytes.Contains(modBytes, []byte("wasi_snapshot_preview1")) {
+		_ = appendAudit(map[string]any{ //nolint:errcheck // best-effort audit
+			"ts":             time.Now().UTC().Format(time.RFC3339Nano),
+			"tool":           "code.sandbox.wasm.run",
+			"span":           "tools.wasm.run",
+			"ms":             time.Since(start).Milliseconds(),
+			"module_bytes":   len(modBytes),
+			"wall_ms":        in.Limits.WallMS,
+			"mem_pages_used": 0,
+			"bytes_out":      0,
+			"event":          "MISSING_IMPORT",
+		})
+		return nil, mustMarshalError("MISSING_IMPORT", "WASI is not available by default; modules requiring 'wasi_snapshot_preview1' are unsupported"), errors.New("missing import: wasi_snapshot_preview1")
+	}
+
+	// Not yet implemented: actual wasm execution. Return a stable stub error.
+	_ = appendAudit(map[string]any{ //nolint:errcheck // best-effort audit
+		"ts":             time.Now().UTC().Format(time.RFC3339Nano),
+		"tool":           "code.sandbox.wasm.run",
+		"span":           "tools.wasm.run",
+		"ms":             time.Since(start).Milliseconds(),
+		"module_bytes":   len(modBytes),
+		"wall_ms":        in.Limits.WallMS,
+		"mem_pages_used": 0,
+		"bytes_out":      0,
+		"event":          "UNIMPLEMENTED",
+	})
+	return nil, mustMarshalError("UNIMPLEMENTED", "wasm execution not yet implemented"), errors.New("unimplemented")
+}
+
+func mustMarshalError(code, msg string) []byte {
+	b, err := json.Marshal(Error{Code: code, Message: msg})
+	if err != nil {
+		return []byte("{\"code\":\"" + code + "\",\"message\":\"" + msg + "\"}")
+	}
+	return b
+}
+
+// appendAudit writes an NDJSON line under .goagent/audit/YYYYMMDD.log at the repo root.
+func appendAudit(entry any) error {
+	b, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	root := moduleRoot()
+	dir := filepath.Join(root, ".goagent", "audit")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	fname := time.Now().UTC().Format("20060102") + ".log"
+	path := filepath.Join(dir, fname)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }() //nolint:errcheck // best-effort close
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+// moduleRoot walks upward from CWD to the directory containing go.mod; falls back to CWD.
+func moduleRoot() string {
+	cwd, err := os.Getwd()
+	if err != nil || cwd == "" {
+		return "."
+	}
+	dir := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return cwd
+		}
+		dir = parent
+	}
+}

--- a/internal/tools/wasmrun/handler_test.go
+++ b/internal/tools/wasmrun/handler_test.go
@@ -1,0 +1,163 @@
+package wasmrun
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+func TestRun_InvalidJSON(t *testing.T) {
+	stdout, stderr, err := Run([]byte("not-json"))
+	if err == nil {
+		t.Fatalf("expected error for invalid JSON")
+	}
+	if len(stdout) != 0 {
+		t.Fatalf("expected no stdout, got: %s", string(stdout))
+	}
+	var e struct{ Code, Message string }
+	if jerr := json.Unmarshal(stderr, &e); jerr != nil {
+		t.Fatalf("stderr not JSON: %v: %s", jerr, string(stderr))
+	}
+	if e.Code != "INVALID_INPUT" {
+		t.Fatalf("expected INVALID_INPUT, got %q (%s)", e.Code, e.Message)
+	}
+}
+
+func TestRun_MissingModuleB64(t *testing.T) {
+	req := map[string]any{
+		"entry":  "main",
+		"input":  "",
+		"limits": map[string]any{"output_kb": 1, "wall_ms": 10, "mem_pages": 1},
+	}
+	b, merr := json.Marshal(req)
+	if merr != nil {
+		t.Fatalf("marshal failed: %v", merr)
+	}
+	stdout, stderr, err := Run(b)
+	if err == nil {
+		t.Fatalf("expected error for missing module_b64")
+	}
+	if len(stdout) != 0 {
+		t.Fatalf("expected no stdout, got: %s", string(stdout))
+	}
+	var e struct{ Code, Message string }
+	if jerr := json.Unmarshal(stderr, &e); jerr != nil {
+		t.Fatalf("stderr not JSON: %v: %s", jerr, string(stderr))
+	}
+	if e.Code != "INVALID_INPUT" {
+		t.Fatalf("expected INVALID_INPUT, got %q (%s)", e.Code, e.Message)
+	}
+}
+
+func TestRun_BadBase64(t *testing.T) {
+	req := map[string]any{
+		"module_b64": "!!!not-base64!!!",
+		"entry":      "main",
+		"input":      "",
+		"limits":     map[string]any{"output_kb": 1, "wall_ms": 10, "mem_pages": 1},
+	}
+	b, merr := json.Marshal(req)
+	if merr != nil {
+		t.Fatalf("marshal failed: %v", merr)
+	}
+	stdout, stderr, err := Run(b)
+	if err == nil {
+		t.Fatalf("expected error for invalid base64")
+	}
+	if len(stdout) != 0 {
+		t.Fatalf("expected no stdout, got: %s", string(stdout))
+	}
+	var e struct{ Code, Message string }
+	if jerr := json.Unmarshal(stderr, &e); jerr != nil {
+		t.Fatalf("stderr not JSON: %v: %s", jerr, string(stderr))
+	}
+	if e.Code != "INVALID_INPUT" {
+		t.Fatalf("expected INVALID_INPUT, got %q (%s)", e.Code, e.Message)
+	}
+}
+
+func TestRun_UnimplementedOnValidInput(t *testing.T) {
+	// module_b64 is valid base64 but not necessarily a valid wasm; current stub only validates base64
+	req := map[string]any{
+		"module_b64": "AA==", // base64 for single zero byte
+		"entry":      "main",
+		"input":      "",
+		"limits":     map[string]any{"output_kb": 1, "wall_ms": 10, "mem_pages": 1},
+	}
+	b, merr := json.Marshal(req)
+	if merr != nil {
+		t.Fatalf("marshal failed: %v", merr)
+	}
+	stdout, stderr, err := Run(b)
+	if err == nil {
+		t.Fatalf("expected unimplemented error")
+	}
+	if len(stdout) != 0 {
+		t.Fatalf("expected no stdout, got: %s", string(stdout))
+	}
+	var e struct{ Code, Message string }
+	if jerr := json.Unmarshal(stderr, &e); jerr != nil {
+		t.Fatalf("stderr not JSON: %v: %s", jerr, string(stderr))
+	}
+	if e.Code != "UNIMPLEMENTED" {
+		t.Fatalf("expected UNIMPLEMENTED, got %q (%s)", e.Code, e.Message)
+	}
+}
+
+func TestRun_InvalidLimits(t *testing.T) {
+	cases := []map[string]any{
+		{"module_b64": "AA==", "entry": "main", "input": "", "limits": map[string]any{"output_kb": 0, "wall_ms": 10, "mem_pages": 1}},
+		{"module_b64": "AA==", "entry": "main", "input": "", "limits": map[string]any{"output_kb": 1, "wall_ms": 0, "mem_pages": 1}},
+		{"module_b64": "AA==", "entry": "main", "input": "", "limits": map[string]any{"output_kb": 1, "wall_ms": 10, "mem_pages": 0}},
+	}
+	for i, req := range cases {
+		b, merr := json.Marshal(req)
+		if merr != nil {
+			t.Fatalf("case %d: marshal failed: %v", i, merr)
+		}
+		stdout, stderr, err := Run(b)
+		if err == nil {
+			t.Fatalf("case %d: expected error for invalid limits", i)
+		}
+		if len(stdout) != 0 {
+			t.Fatalf("case %d: expected no stdout, got: %s", i, string(stdout))
+		}
+		var e struct{ Code, Message string }
+		if jerr := json.Unmarshal(stderr, &e); jerr != nil {
+			t.Fatalf("case %d: stderr not JSON: %v: %s", i, jerr, string(stderr))
+		}
+		if e.Code != "INVALID_INPUT" {
+			t.Fatalf("case %d: expected INVALID_INPUT, got %q (%s)", i, e.Code, e.Message)
+		}
+	}
+}
+
+func TestRun_DenyWASIByDefault(t *testing.T) {
+	// Any bytes containing the string "wasi_snapshot_preview1" should be denied
+	// even before actual execution is implemented.
+	wasmLike := base64.StdEncoding.EncodeToString([]byte("xxwasi_snapshot_preview1xx"))
+	req := map[string]any{
+		"module_b64": wasmLike,
+		"entry":      "main",
+		"input":      "",
+		"limits":     map[string]any{"output_kb": 1, "wall_ms": 10, "mem_pages": 1},
+	}
+	b, merr := json.Marshal(req)
+	if merr != nil {
+		t.Fatalf("marshal failed: %v", merr)
+	}
+	stdout, stderr, err := Run(b)
+	if err == nil {
+		t.Fatalf("expected error for WASI-dependent module")
+	}
+	if len(stdout) != 0 {
+		t.Fatalf("expected no stdout, got: %s", string(stdout))
+	}
+	var e struct{ Code, Message string }
+	if jerr := json.Unmarshal(stderr, &e); jerr != nil {
+		t.Fatalf("stderr not JSON: %v: %s", jerr, string(stderr))
+	}
+	if e.Code != "MISSING_IMPORT" {
+		t.Fatalf("expected MISSING_IMPORT, got %q (%s)", e.Code, e.Message)
+	}
+}

--- a/internal/tools/wasmrun/memory.go
+++ b/internal/tools/wasmrun/memory.go
@@ -1,0 +1,46 @@
+package wasmrun
+
+import (
+	"errors"
+)
+
+// ErrOOBMemory is returned when attempting to read outside the bounds
+// of the guest's linear memory. It standardizes to code "OOB_MEMORY".
+var ErrOOBMemory = errors.New("OOB_MEMORY")
+
+// readLinearMemory returns a copy of length bytes starting at ptr from the
+// provided linear memory slice. It performs strict bounds checks and returns
+// ErrOOBMemory on any out-of-bounds or overflow condition. A length of zero
+// returns an empty slice without error only when ptr is within [0,len] (ptr==len allowed).
+func readLinearMemory(linearMemory []byte, ptr uint32, length uint32) ([]byte, error) {
+	memLen := uint32(len(linearMemory))
+
+	// Zero-length reads are valid only if ptr is not beyond the end.
+	if length == 0 {
+		if ptr > memLen { // strictly beyond end is invalid
+			return nil, ErrOOBMemory
+		}
+		return make([]byte, 0), nil
+	}
+
+	// For non-zero length, ptr must be within [0, len-1]
+	if ptr >= memLen {
+		return nil, ErrOOBMemory
+	}
+
+	// Detect overflow in ptr + length
+	end := ptr + length
+	if end < ptr { // overflow
+		return nil, ErrOOBMemory
+	}
+
+	// Ensure end does not exceed memory length (end index is exclusive).
+	if end > memLen {
+		return nil, ErrOOBMemory
+	}
+
+	// Safe to slice; copy to avoid exposing backing array.
+	out := make([]byte, length)
+	copy(out, linearMemory[ptr:end])
+	return out, nil
+}

--- a/internal/tools/wasmrun/memory_test.go
+++ b/internal/tools/wasmrun/memory_test.go
@@ -1,0 +1,60 @@
+package wasmrun
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestReadLinearMemory_Valid(t *testing.T) {
+	mem := []byte("hello world")
+	b, err := readLinearMemory(mem, 0, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(b, []byte("hello")) {
+		t.Fatalf("want hello, got %q", string(b))
+	}
+	b, err = readLinearMemory(mem, 6, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(b, []byte("world")) {
+		t.Fatalf("want world, got %q", string(b))
+	}
+}
+
+func TestReadLinearMemory_ZeroLength(t *testing.T) {
+	mem := []byte("abc")
+	b, err := readLinearMemory(mem, 1, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(b) != 0 {
+		t.Fatalf("expected empty slice, got %d", len(b))
+	}
+}
+
+func TestReadLinearMemory_OutOfBounds(t *testing.T) {
+	mem := []byte("abc")
+	cases := [][2]uint32{
+		{3, 1}, // ptr == len
+		{4, 0}, // ptr > len
+		{2, 2}, // end == 4 > len 3
+		{0, 4}, // length > len
+	}
+	for i, c := range cases {
+		if _, err := readLinearMemory(mem, c[0], c[1]); err == nil {
+			t.Fatalf("case %d: expected OOB error", i)
+		}
+	}
+}
+
+func TestReadLinearMemory_Overflow(t *testing.T) {
+	mem := make([]byte, 8)
+	// Choose ptr and length that overflow uint32 when summed
+	ptr := uint32(0xFFFFFFF0)
+	length := uint32(0x30)
+	if _, err := readLinearMemory(mem, ptr, length); err == nil {
+		t.Fatalf("expected overflow to be treated as OOB")
+	}
+}

--- a/internal/tools/wasmrun/observability_test.go
+++ b/internal/tools/wasmrun/observability_test.go
@@ -1,0 +1,102 @@
+package wasmrun
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// findRepoRoot locates repository root containing go.mod.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	start, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := start
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("go.mod not found from %s upward", start)
+		}
+		dir = parent
+	}
+}
+
+func waitForAuditFile(t *testing.T, auditDir string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		entries, err := os.ReadDir(auditDir)
+		if err == nil {
+			for _, e := range entries {
+				if !e.IsDir() {
+					return filepath.Join(auditDir, e.Name())
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("audit log not created in %s", auditDir)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestObservability_AuditLineWritten_Unimplemented(t *testing.T) {
+	root := findRepoRoot(t)
+	_ = os.RemoveAll(filepath.Join(root, ".goagent")) //nolint:errcheck // best-effort cleanup
+
+	req := map[string]any{
+		"module_b64": "AA==", // one zero byte
+		"entry":      "main",
+		"input":      "",
+		"limits":     map[string]any{"output_kb": 1, "wall_ms": 10, "mem_pages": 1},
+	}
+	b, _ := json.Marshal(req) //nolint:errcheck // inputs are deterministic
+	stdout, stderr, err := Run(b)
+	if err == nil || len(stdout) != 0 {
+		t.Fatalf("expected unimplemented error with no stdout, got err=%v stdout=%s", err, string(stdout))
+	}
+	var e struct{ Code, Message string }
+	if jerr := json.Unmarshal(stderr, &e); jerr != nil {
+		t.Fatalf("stderr not JSON: %v: %s", jerr, string(stderr))
+	}
+	if e.Code != "UNIMPLEMENTED" {
+		t.Fatalf("expected UNIMPLEMENTED, got %q", e.Code)
+	}
+
+	auditDir := filepath.Join(root, ".goagent", "audit")
+	logFile := waitForAuditFile(t, auditDir, 2*time.Second)
+	data, rerr := os.ReadFile(logFile)
+	if rerr != nil {
+		t.Fatalf("read audit: %v", rerr)
+	}
+	content := string(data)
+	if !strings.Contains(content, "\"tool\":\"code.sandbox.wasm.run\"") {
+		t.Fatalf("audit missing tool field: %s", content)
+	}
+	if !strings.Contains(content, "\"span\":\"tools.wasm.run\"") {
+		t.Fatalf("audit missing span field: %s", content)
+	}
+	if !strings.Contains(content, "\"module_bytes\":1") {
+		t.Fatalf("audit missing module_bytes field: %s", content)
+	}
+	if !strings.Contains(content, "\"wall_ms\":10") {
+		t.Fatalf("audit missing wall_ms field: %s", content)
+	}
+	if !strings.Contains(content, "\"mem_pages_used\":0") {
+		t.Fatalf("audit missing mem_pages_used field: %s", content)
+	}
+	if !strings.Contains(content, "\"bytes_out\":0") {
+		t.Fatalf("audit missing bytes_out field: %s", content)
+	}
+	if !strings.Contains(content, "\"event\":\"UNIMPLEMENTED\"") {
+		t.Fatalf("audit missing UNIMPLEMENTED event: %s", content)
+	}
+}


### PR DESCRIPTION
Adds internal/tools/wasmrun with deterministic input validation (module_b64, limits.wall_ms/output_kb/mem_pages), conservative WASI-deny check (reject wasi_snapshot_preview1), and memory bounds helper+tests. Draft until base scaffolding lands on main. Tracked in FEATURE_CHECKLIST.md.