### PR TITLE
port: prestage coordinator/runner + prompt resolve from develop

### DIFF
--- a/internal/oai/assets/prep_default.md
+++ b/internal/oai/assets/prep_default.md
@@ -1,0 +1,60 @@
+# Smart Prep Prompt (Default)
+
+The goal of this pre-stage is to deterministically derive:
+
+- A concise but complete system prompt suitable for the main run.
+- Zero or more developer prompts to guide style and constraints.
+- Tool configuration hints, including image-generation guidance when applicable.
+- Optional image instructions for downstream image tools.
+
+Requirements:
+
+- Output MUST be Harmony messages JSON: an array of objects with optional `system`, zero-or-more `developer`, and optional `tool_config` and `image_instructions` fields.
+- Do not include `role:"tool"` entries and do not include tool calls in this stage.
+- Be explicit about safety, redaction of secrets, and source attribution.
+
+Guidelines:
+
+- Keep prompts minimal but sufficient. Avoid verbosity that wastes tokens.
+- Prefer declarative constraints to prescriptive long-form text.
+- If image generation is likely, include high-level image guidelines (style, quality, size) without locking to a provider-specific model.
+- Annotate any assumptions clearly.
+
+Steps:
+
+1. Read the user request and any provided context.
+2. Identify missing constraints and fill reasonable defaults.
+3. Propose the system prompt that sets behavior boundaries and goals.
+4. Provide optional developer prompts for formatting, tone, and structure.
+5. Provide optional `tool_config` hints describing which tools are likely useful and with which key parameters.
+6. Provide optional `image_instructions` when image generation is relevant.
+7. Return a single JSON array as the only output.
+
+Example minimal output (JSON):
+
+[
+  {
+    "system": "You are a helpful assistant. Prioritize correctness and cite sources when tools provide them."
+  },
+  {
+    "developer": "Return concise answers; use bullet lists when appropriate."
+  },
+  {
+    "tool_config": {
+      "enable_tools": ["searxng_search","http_fetch","readability_extract"],
+      "hints": {"http_fetch.max_bytes": 1048576}
+    }
+  },
+  {
+    "image_instructions": {
+      "style": "natural",
+      "quality": "standard",
+      "size": "1024x1024"
+    }
+  }
+]
+
+Notes:
+- Keep total token usage modest.
+- Ensure the JSON is syntactically valid.
+- Avoid embedding large text; link via citations instead.

--- a/internal/oai/prestage/coordinator.go
+++ b/internal/oai/prestage/coordinator.go
@@ -1,0 +1,96 @@
+package prestage
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hyperifyio/goagent/internal/oai"
+	"github.com/hyperifyio/goagent/internal/state"
+)
+
+// PrestageRunner abstracts the runner so tests can stub it.
+// The concrete Runner in runner.go implements this interface.
+type PrestageRunner interface {
+	Run(ctx context.Context, prompt string) (oai.ChatCompletionsResponse, error)
+}
+
+// Coordinator wires restore-before-prep behavior with override precedence.
+// If a state bundle is available and refinement is not requested and there are
+// no explicit overrides, Coordinator will reuse the persisted prompts and
+// settings without invoking the runner.
+type Coordinator struct {
+	// Optional state directory. When empty, restore is disabled.
+	StateDir string
+	// Optional scope key; when set, restored bundle must match this key.
+	ScopeKey string
+	// When true, forces a new pre-stage run instead of restoring.
+	Refine bool
+	// Overrides from CLI: explicit prompt strings and pre-joined file contents.
+	PrepPrompts     []string
+	PrepFilesJoined string
+
+	// Runner used when a live pre-stage call is required.
+	Runner PrestageRunner
+
+	// Warnf, when set, is used to emit a single-line warning message.
+	// It is called at most once per Execute() invocation.
+	Warnf func(format string, args ...any)
+}
+
+// Outcome captures the result of Execute.
+type Outcome struct {
+	// UsedRestore indicates a persisted bundle was reused and Runner was not called.
+	UsedRestore bool
+	// Restored is the bundle that was reused when UsedRestore is true.
+	Restored *state.StateBundle
+	// PromptUsed is the prompt text sent to Runner when UsedRestore is false.
+	PromptUsed string
+	// Response is the model response when Runner was called.
+	Response oai.ChatCompletionsResponse
+}
+
+// Execute performs restore-before-prep logic.
+// Precedence for the effective pre-stage prompt source:
+//  1. explicit prompt overrides (PrepPrompts)
+//  2. file-based overrides (PrepFilesJoined)
+//  3. restored bundle (when available, ScopeKey matches, and Refine==false)
+//  4. embedded default
+//
+// Note: This function does not save state; persistence is handled elsewhere.
+func (c *Coordinator) Execute(ctx context.Context) (Outcome, error) {
+	var out Outcome
+
+	// If overrides are present, they take precedence and force a live call.
+	overrideSource, overrideText := oai.ResolvePrepPrompt(c.PrepPrompts, c.PrepFilesJoined)
+	overridesProvided := overrideSource == "override" && strings.TrimSpace(overrideText) != ""
+
+	// If refine is requested but explicit overrides are provided, warn and proceed.
+	if overridesProvided && c.Refine && c.Warnf != nil {
+		c.Warnf("pre-stage: explicit overrides provided while -state-refine is set; proceeding with overrides")
+	}
+
+	if !overridesProvided && !c.Refine && strings.TrimSpace(c.StateDir) != "" {
+		if b, err := state.LoadLatestStateBundle(c.StateDir); err == nil && b != nil {
+			if strings.TrimSpace(c.ScopeKey) == "" || b.ScopeKey == c.ScopeKey {
+				out.UsedRestore = true
+				out.Restored = b
+				return out, nil
+			}
+			// scope mismatch → ignore and fall through
+		}
+		// On any load error, fall through to live run
+	}
+
+	// Determine the prompt to use for a live pre-stage run
+	_, prompt := oai.ResolvePrepPrompt(c.PrepPrompts, c.PrepFilesJoined)
+
+	out.PromptUsed = prompt
+	if c.Runner != nil {
+		resp, err := c.Runner.Run(ctx, prompt)
+		if err != nil {
+			return out, err
+		}
+		out.Response = resp
+	}
+	return out, nil
+}

--- a/internal/oai/prestage/coordinator_test.go
+++ b/internal/oai/prestage/coordinator_test.go
@@ -1,0 +1,186 @@
+package prestage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hyperifyio/goagent/internal/oai"
+	"github.com/hyperifyio/goagent/internal/state"
+)
+
+// stubRunner implements PrestageRunner for tests.
+type stubRunner struct {
+	calls      int
+	lastPrompt string
+	resp       oai.ChatCompletionsResponse
+	err        error
+}
+
+func (s *stubRunner) Run(ctx context.Context, prompt string) (oai.ChatCompletionsResponse, error) {
+	s.calls++
+	s.lastPrompt = prompt
+	return s.resp, s.err
+}
+
+func writeValidBundle(t *testing.T, dir string, scope string) *state.StateBundle {
+	t.Helper()
+	b := &state.StateBundle{
+		Version:      "1",
+		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
+		ToolVersion:  "test",
+		ModelID:      "gpt-x",
+		BaseURL:      "http://example.test",
+		ToolsetHash:  "abc",
+		ScopeKey:     scope,
+		Prompts:      map[string]string{"system": "S", "developer": "D"},
+		PrepSettings: map[string]any{"k": "v"},
+		Context:      map[string]any{"a": 1},
+		ToolCaps:     map[string]any{"c": true},
+		Custom:       map[string]any{"x": "y"},
+	}
+	b.SourceHash = state.ComputeSourceHash(b.ModelID, b.BaseURL, b.ToolsetHash, b.ScopeKey)
+	if err := state.SaveStateBundle(dir, b); err != nil {
+		t.Fatalf("SaveStateBundle: %v", err)
+	}
+	return b
+}
+
+func TestCoordinator_UsesRestoreWhenAvailableAndNoOverrides(t *testing.T) {
+	tmp := t.TempDir()
+	bundle := writeValidBundle(t, tmp, "scope-1")
+
+	c := &Coordinator{StateDir: tmp, ScopeKey: "scope-1", Runner: &stubRunner{}}
+	out, err := c.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if !out.UsedRestore || out.Restored == nil {
+		t.Fatalf("expected restore to be used, got %+v", out)
+	}
+	if out.Restored.ScopeKey != bundle.ScopeKey {
+		t.Fatalf("restored bundle mismatch: %+v", out.Restored)
+	}
+}
+
+func TestCoordinator_SkipsRestoreOnOverridesAndCallsRunner(t *testing.T) {
+	tmp := t.TempDir()
+	_ = writeValidBundle(t, tmp, "scope-1")
+
+	s := &stubRunner{resp: oai.ChatCompletionsResponse{Model: "m"}}
+	c := &Coordinator{StateDir: tmp, ScopeKey: "scope-1", PrepPrompts: []string{"OVERRIDE"}, Runner: s}
+	out, err := c.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if out.UsedRestore {
+		t.Fatalf("did not expect restore when overrides present")
+	}
+	if s.calls != 1 || s.lastPrompt == "" {
+		t.Fatalf("runner not called with prompt; calls=%d prompt=%q", s.calls, s.lastPrompt)
+	}
+}
+
+func TestCoordinator_IgnoreRestoreWhenScopeMismatch(t *testing.T) {
+	tmp := t.TempDir()
+	_ = writeValidBundle(t, tmp, "scope-1")
+	s := &stubRunner{resp: oai.ChatCompletionsResponse{Model: "m"}}
+	c := &Coordinator{StateDir: tmp, ScopeKey: "other-scope", Runner: s}
+	out, err := c.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if out.UsedRestore {
+		t.Fatalf("expected live run due to scope mismatch")
+	}
+	if s.calls != 1 {
+		t.Fatalf("runner should be called once, got %d", s.calls)
+	}
+}
+
+func TestCoordinator_RefineForcesLiveRun(t *testing.T) {
+	tmp := t.TempDir()
+	_ = writeValidBundle(t, tmp, "s")
+	s := &stubRunner{resp: oai.ChatCompletionsResponse{Model: "m"}}
+	c := &Coordinator{StateDir: tmp, ScopeKey: "s", Refine: true, Runner: s}
+	out, err := c.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if out.UsedRestore {
+		t.Fatalf("expected live run when Refine=true")
+	}
+	if s.calls != 1 {
+		t.Fatalf("runner should be called once, got %d", s.calls)
+	}
+}
+
+func TestCoordinator_WarnsOnceWhenOverridesWithRefine(t *testing.T) {
+	s := &stubRunner{resp: oai.ChatCompletionsResponse{Model: "m"}}
+	var warns []string
+	c := &Coordinator{Refine: true, PrepPrompts: []string{"OVR"}, Runner: s, Warnf: func(format string, args ...any) {
+		warns = append(warns, fmt.Sprintf(format, args...))
+	}}
+	out, err := c.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if out.UsedRestore {
+		t.Fatalf("should not restore when overrides present")
+	}
+	if len(warns) != 1 {
+		t.Fatalf("expected exactly one warning, got %d: %#v", len(warns), warns)
+	}
+	if !strings.Contains(strings.ToLower(warns[0]), "override") || !strings.Contains(strings.ToLower(warns[0]), "refine") {
+		t.Fatalf("warning should mention override and refine: %q", warns[0])
+	}
+}
+
+func TestCoordinator_NoStateDirFallsBackToDefaultPrompt(t *testing.T) {
+	s := &stubRunner{resp: oai.ChatCompletionsResponse{Model: "m"}}
+	c := &Coordinator{Runner: s}
+	out, err := c.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if out.UsedRestore || out.Restored != nil {
+		t.Fatalf("should not use restore without state dir: %+v", out)
+	}
+	if s.calls != 1 || strings.TrimSpace(out.PromptUsed) == "" {
+		t.Fatalf("runner should be called with default prompt; calls=%d prompt=%q", s.calls, out.PromptUsed)
+	}
+}
+
+func TestCoordinator_IgnoresCorruptStateAndRunsLive(t *testing.T) {
+	tmp := t.TempDir()
+	// Create corrupt latest.json
+	if err := os.WriteFile(filepath.Join(tmp, "latest.json"), []byte("not-json"), 0o600); err != nil {
+		t.Fatalf("write latest.json: %v", err)
+	}
+	s := &stubRunner{resp: oai.ChatCompletionsResponse{Model: "m"}}
+	c := &Coordinator{StateDir: tmp, Runner: s}
+	out, err := c.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if out.UsedRestore {
+		t.Fatalf("did not expect restore with corrupt state")
+	}
+	if s.calls != 1 {
+		t.Fatalf("runner should be called once, got %d", s.calls)
+	}
+}
+
+func TestCoordinator_PropagatesRunnerError(t *testing.T) {
+	s := &stubRunner{err: errors.New("boom")}
+	c := &Coordinator{Runner: s}
+	_, err := c.Execute(context.Background())
+	if err == nil {
+		t.Fatalf("expected error from runner")
+	}
+}

--- a/internal/oai/prestage/e2e_state_persistence_test.go
+++ b/internal/oai/prestage/e2e_state_persistence_test.go
@@ -1,0 +1,179 @@
+package prestage
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hyperifyio/goagent/internal/state"
+)
+
+// readLatestPointer is a tiny helper to read latest.json's path field.
+func readLatestPointer(t *testing.T, dir string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, "latest.json"))
+	if err != nil {
+		t.Fatalf("read latest.json: %v", err)
+	}
+	var ptr struct {
+		Version string `json:"version"`
+		Path    string `json:"path"`
+		SHA256  string `json:"sha256"`
+	}
+	if err := json.Unmarshal(b, &ptr); err != nil {
+		t.Fatalf("unmarshal latest.json: %v", err)
+	}
+	if ptr.Version != "1" || strings.TrimSpace(ptr.Path) == "" {
+		t.Fatalf("invalid latest pointer: %#v", ptr)
+	}
+	return ptr.Path
+}
+
+func countSnapshotFiles(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	n := 0
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "state-") && strings.HasSuffix(e.Name(), ".json") {
+			n++
+		}
+	}
+	return n
+}
+
+func TestE2E_State_SaveAndRestore(t *testing.T) {
+	tmp := t.TempDir()
+	scope := "testscope"
+	b1 := &state.StateBundle{
+		Version:     "1",
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+		ToolVersion: "test",
+		ModelID:     "gpt-x",
+		BaseURL:     "http://api.example",
+		ToolsetHash: "toolset-1",
+		ScopeKey:    scope,
+		Prompts:     map[string]string{"system": "S", "developer": "dev1"},
+	}
+	b1.SourceHash = state.ComputeSourceHash(b1.ModelID, b1.BaseURL, b1.ToolsetHash, b1.ScopeKey)
+	if err := state.SaveStateBundle(tmp, b1); err != nil {
+		t.Fatalf("SaveStateBundle(b1): %v", err)
+	}
+	_ = readLatestPointer(t, tmp)
+	if count := countSnapshotFiles(t, tmp); count != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", count)
+	}
+	s1 := &stubRunner{}
+	c1 := &Coordinator{StateDir: tmp, ScopeKey: scope, Runner: s1}
+	out1, err := c1.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute (restore) error: %v", err)
+	}
+	if !out1.UsedRestore || out1.Restored == nil {
+		t.Fatalf("expected restore, got %+v", out1)
+	}
+	if s1.calls != 0 {
+		t.Fatalf("runner should not be called on restore, calls=%d", s1.calls)
+	}
+}
+
+func TestE2E_State_RefineAdvancesLatest(t *testing.T) {
+	tmp := t.TempDir()
+	scope := "testscope"
+	b1 := &state.StateBundle{
+		Version:     "1",
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+		ToolVersion: "test",
+		ModelID:     "gpt-x",
+		BaseURL:     "http://api.example",
+		ToolsetHash: "toolset-1",
+		ScopeKey:    scope,
+		Prompts:     map[string]string{"system": "S", "developer": "dev1"},
+	}
+	b1.SourceHash = state.ComputeSourceHash(b1.ModelID, b1.BaseURL, b1.ToolsetHash, b1.ScopeKey)
+	if err := state.SaveStateBundle(tmp, b1); err != nil {
+		t.Fatalf("SaveStateBundle(b1): %v", err)
+	}
+	firstPtr := readLatestPointer(t, tmp)
+	prev, err := state.LoadLatestStateBundle(tmp)
+	if err != nil || prev == nil {
+		t.Fatalf("LoadLatestStateBundle: %v, prev=%v", err, prev)
+	}
+	b2, err := state.RefineStateBundle(prev, "tighten temperature to 0.2", "hello user")
+	if err != nil {
+		t.Fatalf("RefineStateBundle: %v", err)
+	}
+	if err := state.SaveStateBundle(tmp, b2); err != nil {
+		t.Fatalf("SaveStateBundle(b2): %v", err)
+	}
+	secondPtr := readLatestPointer(t, tmp)
+	if secondPtr == firstPtr {
+		t.Fatalf("latest pointer did not advance: %q", secondPtr)
+	}
+	if count := countSnapshotFiles(t, tmp); count != 2 {
+		t.Fatalf("expected 2 snapshots after refine save, got %d", count)
+	}
+}
+
+func TestE2E_State_PromptPrecedence(t *testing.T) {
+	tmp := t.TempDir()
+	scope := "testscope"
+	b1 := &state.StateBundle{
+		Version:     "1",
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+		ToolVersion: "test",
+		ModelID:     "gpt-x",
+		BaseURL:     "http://api.example",
+		ToolsetHash: "toolset-1",
+		ScopeKey:    scope,
+		Prompts:     map[string]string{"system": "S", "developer": "dev1"},
+	}
+	b1.SourceHash = state.ComputeSourceHash(b1.ModelID, b1.BaseURL, b1.ToolsetHash, b1.ScopeKey)
+	if err := state.SaveStateBundle(tmp, b1); err != nil {
+		t.Fatalf("SaveStateBundle(b1): %v", err)
+	}
+	// Overrides win over restore
+	s2 := &stubRunner{}
+	c2 := &Coordinator{StateDir: tmp, ScopeKey: scope, PrepPrompts: []string{"OVERRIDE_PROMPT"}, Runner: s2}
+	out2, err := c2.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute (override) error: %v", err)
+	}
+	if out2.UsedRestore {
+		t.Fatalf("did not expect restore when overrides provided")
+	}
+	if s2.calls != 1 || s2.lastPrompt != "OVERRIDE_PROMPT" {
+		t.Fatalf("runner should be called with override; calls=%d, prompt=%q", s2.calls, s2.lastPrompt)
+	}
+	// Refine, then restore refined without overrides
+	prev, err := state.LoadLatestStateBundle(tmp)
+	if err != nil || prev == nil {
+		t.Fatalf("LoadLatestStateBundle: %v, prev=%v", err, prev)
+	}
+	b2, err := state.RefineStateBundle(prev, "tighten temperature to 0.2", "hello user")
+	if err != nil {
+		t.Fatalf("RefineStateBundle: %v", err)
+	}
+	if err := state.SaveStateBundle(tmp, b2); err != nil {
+		t.Fatalf("SaveStateBundle(b2): %v", err)
+	}
+	s3 := &stubRunner{}
+	c3 := &Coordinator{StateDir: tmp, ScopeKey: scope, Runner: s3}
+	out3, err := c3.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute (restore refined) error: %v", err)
+	}
+	if !out3.UsedRestore || out3.Restored == nil {
+		t.Fatalf("expected restore of refined bundle, got %+v", out3)
+	}
+	dev := out3.Restored.Prompts["developer"]
+	if !strings.Contains(dev, "tighten temperature to 0.2") || !strings.Contains(dev, "USER: hello user") {
+		t.Fatalf("refined developer prompt missing expected parts: %q", dev)
+	}
+}

--- a/internal/oai/prestage/runner.go
+++ b/internal/oai/prestage/runner.go
@@ -1,0 +1,45 @@
+package prestage
+
+import (
+	"context"
+	"time"
+
+	"github.com/hyperifyio/goagent/internal/oai"
+)
+
+// Runner sends the pre-stage prompt to the model and returns the raw response.
+// It is intentionally minimal and only wires the resolved prompt as the user message.
+type Runner struct {
+	Client *oai.Client
+	Model  string
+	// Optional knobs; callers may set appropriate values based on CLI flags.
+	Temperature *float64
+	TopP        *float64
+	Timeout     time.Duration
+	// When true, request JSON mode (response_format {type:"json_object"}) if supported.
+	JSONMode bool
+}
+
+// Run executes a single non-streaming chat completion for the pre-stage using
+// the provided resolved prompt text. The user message content will be exactly
+// the provided prompt. The system message is omitted by default.
+func (r *Runner) Run(ctx context.Context, prompt string) (oai.ChatCompletionsResponse, error) {
+	req := oai.ChatCompletionsRequest{
+		Model: r.Model,
+		Messages: []oai.Message{
+			{Role: oai.RoleUser, Content: prompt},
+		},
+		TopP:        r.TopP,
+		Temperature: r.Temperature,
+	}
+	// Enforce one‑knob rule here: if TopP is set, do not send Temperature at all.
+	if r.TopP != nil {
+		req.Temperature = nil
+	}
+	if r.JSONMode {
+		req.ResponseFormat = &oai.ResponseFormat{Type: "json_object"}
+	}
+	// Tag audit with stage label "prep" for observability
+	ctx = oai.WithAuditStage(ctx, "prep")
+	return r.Client.CreateChatCompletion(ctx, req)
+}

--- a/internal/oai/prestage/runner_test.go
+++ b/internal/oai/prestage/runner_test.go
@@ -1,0 +1,87 @@
+package prestage
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/hyperifyio/goagent/internal/oai"
+)
+
+func TestRunner_SendsResolvedPromptAsUserMessage(t *testing.T) {
+	// Arrange a fake OpenAI-compatible server that asserts first user message equals prompt
+	const wantPrompt = "PREP_PROMPT_TEXT"
+	var gotReq oai.ChatCompletionsRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			http.Error(w, "wrong path", http.StatusNotFound)
+			return
+		}
+		dec := json.NewDecoder(r.Body)
+		if err := dec.Decode(&gotReq); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		// Minimal valid response
+		if err := json.NewEncoder(w).Encode(oai.ChatCompletionsResponse{Model: gotReq.Model}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}))
+	defer server.Close()
+
+	client := oai.NewClient(server.URL, "", 2*time.Second)
+	runner := &Runner{Client: client, Model: "gpt-test-1"}
+
+	// Act
+	_, err := runner.Run(context.Background(), wantPrompt)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Assert
+	if len(gotReq.Messages) == 0 || gotReq.Messages[0].Role != oai.RoleUser || gotReq.Messages[0].Content != wantPrompt {
+		t.Fatalf("unexpected first message: %+v", gotReq.Messages)
+	}
+}
+
+func TestRunner_OneKnobRuleAndJSONMode(t *testing.T) {
+	// Arrange a fake server that captures request
+	var gotReq oai.ChatCompletionsRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dec := json.NewDecoder(r.Body)
+		if err := dec.Decode(&gotReq); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(oai.ChatCompletionsResponse{Model: gotReq.Model}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}))
+	defer server.Close()
+
+	client := oai.NewClient(server.URL, "", 2*time.Second)
+	temp := 0.5
+	topP := 0.9
+	runner := &Runner{Client: client, Model: "gpt-test-1", Temperature: &temp, TopP: &topP, JSONMode: true}
+
+	_, err := runner.Run(context.Background(), "x")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// When TopP is set, temperature must be omitted per one‑knob rule
+	if gotReq.TopP == nil || *gotReq.TopP != 0.9 {
+		t.Fatalf("expected top_p 0.9, got %+v", gotReq.TopP)
+	}
+	if gotReq.Temperature != nil {
+		t.Fatalf("expected temperature omitted when top_p set; got %v", *gotReq.Temperature)
+	}
+	// JSON mode should be requested
+	if gotReq.ResponseFormat == nil || gotReq.ResponseFormat.Type != "json_object" {
+		t.Fatalf("expected response_format json_object, got %+v", gotReq.ResponseFormat)
+	}
+}

--- a/internal/oai/prompt_resolve.go
+++ b/internal/oai/prompt_resolve.go
@@ -1,0 +1,38 @@
+package oai
+
+import (
+	"strings"
+	"unicode"
+)
+
+// JoinPrompts concatenates parts with two newlines and trims trailing whitespace.
+func JoinPrompts(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	trimmed := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed = append(trimmed, trimRightNLTab(p))
+	}
+	joined := strings.Join(trimmed, "\n\n")
+	return strings.TrimRightFunc(joined, unicode.IsSpace)
+}
+
+func trimRightNLTab(s string) string {
+	return strings.TrimRightFunc(s, func(r rune) bool {
+		return r == '\n' || r == '\r' || r == '\t'
+	})
+}
+
+// ResolvePrepPrompt selects the effective pre-stage prompt text and its source.
+// Order: explicit prompt strings (override) > joined file contents (override) > embedded default.
+func ResolvePrepPrompt(prepPrompts []string, prepFilesJoined string) (source string, text string) {
+	if len(prepPrompts) > 0 {
+		return "override", JoinPrompts(prepPrompts)
+	}
+	if s := strings.TrimSpace(prepFilesJoined); s != "" {
+		// trim trailing whitespace but preserve internal spacing
+		return "override", strings.TrimRightFunc(s, func(r rune) bool { return r == '\n' || r == '\r' || r == '\t' || r == ' ' })
+	}
+	return "default", DefaultPrepPrompt()
+}

--- a/internal/oai/prompts.go
+++ b/internal/oai/prompts.go
@@ -1,0 +1,9 @@
+package oai
+
+import _ "embed"
+
+//go:embed assets/prep_default.md
+var prepDefaultPrompt string
+
+// DefaultPrepPrompt returns the embedded default pre-stage prompt.
+func DefaultPrepPrompt() string { return prepDefaultPrompt }

--- a/internal/state/refine.go
+++ b/internal/state/refine.go
@@ -1,0 +1,103 @@
+package state
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+// RefineStateBundle produces a new StateBundle derived from prev by applying a
+// deterministic refinement. It preserves unspecified fields, updates CreatedAt
+// to the current UTC time (RFC3339), recomputes SourceHash, and records PrevSHA
+// as the SHA-256 (hex) of the canonical JSON of the previous bundle.
+//
+// The refinement strategy is intentionally simple and deterministic:
+//   - Prompts["developer"] is appended with two new paragraphs that include the
+//     refineInput and userPrompt, separated by blank lines.
+//   - Other fields are preserved as-is.
+func RefineStateBundle(prev *StateBundle, refineInput string, userPrompt string) (*StateBundle, error) {
+	if prev == nil {
+		return nil, errors.New("nil prev")
+	}
+	if err := prev.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Compute prev SHA over the same canonical form we persist (indent to match SaveStateBundle)
+	prevJSON, err := json.MarshalIndent(prev, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	prevSum := sha256.Sum256(prevJSON)
+	prevSHAHex := hex.EncodeToString(prevSum[:])
+
+	// Deep-ish copy helpers
+	cloneStrMap := func(in map[string]string) map[string]string {
+		if in == nil {
+			return nil
+		}
+		out := make(map[string]string, len(in))
+		for k, v := range in {
+			out[k] = v
+		}
+		return out
+	}
+	cloneAnyMap := func(in map[string]any) map[string]any {
+		if in == nil {
+			return nil
+		}
+		out := make(map[string]any, len(in))
+		for k, v := range in {
+			out[k] = v
+		}
+		return out
+	}
+
+	prompts := cloneStrMap(prev.Prompts)
+	if prompts == nil {
+		prompts = make(map[string]string)
+	}
+
+	// Append deterministic refinement note to developer prompt
+	dev := prompts["developer"]
+	var parts []string
+	if strings.TrimSpace(dev) != "" {
+		parts = append(parts, dev)
+	}
+	if strings.TrimSpace(refineInput) != "" {
+		parts = append(parts, refineInput)
+	}
+	if strings.TrimSpace(userPrompt) != "" {
+		parts = append(parts, "USER: "+userPrompt)
+	}
+	prompts["developer"] = strings.TrimSpace(strings.Join(parts, "\n\n"))
+
+	// Timestamp: ensure it advances at least by 1s if equal to previous
+	now := time.Now().UTC().Truncate(time.Second)
+	if prev.CreatedAt == now.Format(time.RFC3339) {
+		now = now.Add(time.Second)
+	}
+
+	newBundle := &StateBundle{
+		Version:      prev.Version,
+		CreatedAt:    now.Format(time.RFC3339),
+		ToolVersion:  prev.ToolVersion,
+		ModelID:      prev.ModelID,
+		BaseURL:      prev.BaseURL,
+		ToolsetHash:  prev.ToolsetHash,
+		ScopeKey:     prev.ScopeKey,
+		Prompts:      prompts,
+		PrepSettings: cloneAnyMap(prev.PrepSettings),
+		Context:      cloneAnyMap(prev.Context),
+		ToolCaps:     cloneAnyMap(prev.ToolCaps),
+		Custom:       cloneAnyMap(prev.Custom),
+		// Recompute based on identifying fields
+		SourceHash: ComputeSourceHash(prev.ModelID, prev.BaseURL, prev.ToolsetHash, prev.ScopeKey),
+		PrevSHA:    prevSHAHex,
+	}
+
+	return newBundle, nil
+}


### PR DESCRIPTION
## Summary
- Ports prestage coordinator/runner and prompt resolution utilities from develop into main codebase structure.
- Adds embedded default prep prompt and state refinement helper required by tests.

## Rationale
Content-based comparison of `work/develop` vs working tree showed prestage components (`internal/oai/prestage/{coordinator,runner}`) and prompt resolution (`DefaultPrepPrompt`, `JoinPrompts`, `ResolvePrepPrompt`) existed only in develop. Main had merge/parse utilities and CLI integration but lacked the coordinator/runner and prompt embed. Tests from develop referencing these symbols failed on main until implemented.

## Details
- New files: `internal/oai/prestage/{coordinator.go,runner.go}` with tests; `internal/oai/{prompts.go,prompt_resolve.go,assets/prep_default.md}`; `internal/state/refine.go`.
- Aligns with main architecture (no changes to CLI flags/flow) and integrates cleanly with existing `oai` types and audit tagging.
- Full `go test ./...` is green locally.

## Notes
- This is a draft until CI passes. No branch pointers changed; develop mirror in `work/develop` remains read-only.