### PR TITLE
Port internal/tools/image scaffold from develop

### DIFF
--- a/internal/tools/image/client.go
+++ b/internal/tools/image/client.go
@@ -1,0 +1,47 @@
+package image
+
+import (
+	"net/http"
+	"time"
+)
+
+// RetryPolicy controls retry behavior for image HTTP calls.
+// MaxRetries specifies the number of retries after the initial attempt.
+// Backoff specifies the base backoff duration between attempts.
+type RetryPolicy struct {
+	MaxRetries int
+	Backoff    time.Duration
+}
+
+// Client is a minimal HTTP client wrapper for image requests that carries
+// the resolved timeout and retry policy.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+	retry      RetryPolicy
+}
+
+// NewClient constructs a Client with the provided configuration.
+// The httpTimeout applies to the underlying http.Client Timeout.
+// Retries and backoff are stored in a simple RetryPolicy.
+func NewClient(baseURL, apiKey string, httpTimeout time.Duration, retries int, backoff time.Duration) *Client {
+	if httpTimeout <= 0 {
+		httpTimeout = 90 * time.Second
+	}
+	if retries < 0 {
+		retries = 0
+	}
+	return &Client {
+		baseURL: baseURL,
+		apiKey: apiKey,
+		httpClient: &http.Client{ Timeout: httpTimeout },
+		retry: RetryPolicy{ MaxRetries: retries, Backoff: backoff },
+	}
+}
+
+// HTTPTimeout returns the configured HTTP timeout.
+func (c *Client) HTTPTimeout() time.Duration { return c.httpClient.Timeout }
+
+// Retry returns the configured RetryPolicy.
+func (c *Client) Retry() RetryPolicy { return c.retry }

--- a/internal/tools/image/client_test.go
+++ b/internal/tools/image/client_test.go
@@ -1,0 +1,31 @@
+package image
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewClient_AppliesTimeoutAndRetry(t *testing.T) {
+	c := NewClient("https://example", "key", 3*time.Second, 5, 750*time.Millisecond)
+	if got := c.HTTPTimeout(); got != 3*time.Second {
+		t.Fatalf("HTTPTimeout=%s; want 3s", got)
+	}
+	r := c.Retry()
+	if r.MaxRetries != 5 {
+		t.Fatalf("MaxRetries=%d; want 5", r.MaxRetries)
+	}
+	if r.Backoff != 750*time.Millisecond {
+		t.Fatalf("Backoff=%s; want 750ms", r.Backoff)
+	}
+}
+
+func TestNewClient_NormalizesInputs(t *testing.T) {
+	c := NewClient("https://example", "key", 0, -1, 0)
+	if got := c.HTTPTimeout(); got <= 0 {
+		t.Fatalf("HTTPTimeout=%s; want > 0 default", got)
+	}
+	r := c.Retry()
+	if r.MaxRetries != 0 {
+		t.Fatalf("MaxRetries=%d; want 0", r.MaxRetries)
+	}
+}

--- a/internal/tools/image/options.go
+++ b/internal/tools/image/options.go
@@ -1,0 +1,13 @@
+package image
+
+// Options holds configuration for image generation flows.
+// Currently it carries only the model identifier used by the backend.
+// Additional fields will be added as new capabilities are introduced.
+type Options struct {
+	Model string
+}
+
+// NewOptions constructs an Options value using the provided model identifier.
+func NewOptions(model string) Options {
+	return Options{Model: model}
+}

--- a/internal/tools/image/options_test.go
+++ b/internal/tools/image/options_test.go
@@ -1,0 +1,10 @@
+package image
+
+import "testing"
+
+func TestNewOptions_SetsModel(t *testing.T) {
+	opt := NewOptions("foo")
+	if opt.Model != "foo" {
+		t.Fatalf("Model=%q; want foo", opt.Model)
+	}
+}


### PR DESCRIPTION
## Summary
- Ports `internal/tools/image` scaffold (Options and HTTP client) from develop mirror at `work/develop`.
- Confirmed missing in main via content search: no `internal/tools/image` package or references existed.
- Added minimal `Options{Model}` and `Client` with timeout/retry metadata to align with develop’s capabilities.

## Rationale
A content-based comparison of `work/develop` vs main showed `internal/tools/image/{options.go,client.go}` and tests present only in develop. Whole-repo search on main found no equivalent types or functions, and existing `img_create` tool interacts directly with HTTP. This PR introduces the small, shared scaffolding to avoid divergence and enable future integration.

## Notes on adaptation
- Code copied with minimal adjustments to fit main’s `internal` module structure; no behavior changes to existing tools.
- Tests added to ensure construction semantics and defaults match develop.

## Testing
- `go test ./...` passes locally.

## Next steps
- If main later adopts a higher-level image driver, this scaffold will be the integration point.