### PR TITLE
port(internal/tools/image): port image client/options from develop

### DIFF
--- a/internal/tools/image/client.go
+++ b/internal/tools/image/client.go
@@ -1,0 +1,47 @@
+package image
+
+import (
+	"net/http"
+	"time"
+)
+
+// RetryPolicy controls retry behavior for image HTTP calls.
+// MaxRetries specifies the number of retries after the initial attempt.
+// Backoff specifies the base backoff duration between attempts.
+type RetryPolicy struct {
+	MaxRetries int
+	Backoff    time.Duration
+}
+
+// Client is a minimal HTTP client wrapper for image requests that carries
+// the resolved timeout and retry policy.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+	retry      RetryPolicy
+}
+
+// NewClient constructs a Client with the provided configuration.
+// The httpTimeout applies to the underlying http.Client Timeout.
+// Retries and backoff are stored in a simple RetryPolicy.
+func NewClient(baseURL, apiKey string, httpTimeout time.Duration, retries int, backoff time.Duration) *Client {
+	if httpTimeout <= 0 {
+		httpTimeout = 90 * time.Second
+	}
+	if retries < 0 {
+		retries = 0
+	}
+	return &Client {
+		baseURL: baseURL,
+		apiKey: apiKey,
+		httpClient: &http.Client{ Timeout: httpTimeout },
+		retry: RetryPolicy{ MaxRetries: retries, Backoff: backoff },
+	}
+}
+
+// HTTPTimeout returns the configured HTTP timeout.
+func (c *Client) HTTPTimeout() time.Duration { return c.httpClient.Timeout }
+
+// Retry returns the configured RetryPolicy.
+func (c *Client) Retry() RetryPolicy { return c.retry }

--- a/internal/tools/image/client_test.go
+++ b/internal/tools/image/client_test.go
@@ -1,0 +1,31 @@
+package image
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewClient_AppliesTimeoutAndRetry(t *testing.T) {
+	c := NewClient("https://example", "key", 3*time.Second, 5, 750*time.Millisecond)
+	if got := c.HTTPTimeout(); got != 3*time.Second {
+		t.Fatalf("HTTPTimeout=%s; want 3s", got)
+	}
+	r := c.Retry()
+	if r.MaxRetries != 5 {
+		t.Fatalf("MaxRetries=%d; want 5", r.MaxRetries)
+	}
+	if r.Backoff != 750*time.Millisecond {
+		t.Fatalf("Backoff=%s; want 750ms", r.Backoff)
+	}
+}
+
+func TestNewClient_NormalizesInputs(t *testing.T) {
+	c := NewClient("https://example", "key", 0, -1, 0)
+	if got := c.HTTPTimeout(); got <= 0 {
+		t.Fatalf("HTTPTimeout=%s; want > 0 default", got)
+	}
+	r := c.Retry()
+	if r.MaxRetries != 0 {
+		t.Fatalf("MaxRetries=%d; want 0", r.MaxRetries)
+	}
+}

--- a/internal/tools/image/options.go
+++ b/internal/tools/image/options.go
@@ -1,0 +1,13 @@
+package image
+
+// Options holds configuration for image generation flows.
+// Currently it carries only the model identifier used by the backend.
+// Additional fields will be added as new capabilities are introduced.
+type Options struct {
+	Model string
+}
+
+// NewOptions constructs an Options value using the provided model identifier.
+func NewOptions(model string) Options {
+	return Options{Model: model}
+}

--- a/internal/tools/image/options_test.go
+++ b/internal/tools/image/options_test.go
@@ -1,0 +1,10 @@
+package image
+
+import "testing"
+
+func TestNewOptions_SetsModel(t *testing.T) {
+	opt := NewOptions("foo")
+	if opt.Model != "foo" {
+		t.Fatalf("Model=%q; want foo", opt.Model)
+	}
+}


### PR DESCRIPTION
## Summary
- Ports `internal/tools/image` (client + options) and unit tests from `develop` mirror at `work/develop` to `main`.
- Established missing feature via content-based comparison: `work/develop/internal/tools/image/{client,options}*.go` not present anywhere under root; no equivalent types or functions found by repository-wide search.
- Verified that image flow on main currently relies on `tools/cmd/img_create` and `agentcli` integration; this change adds the internal client/options used by develop without altering existing flows.

## Rationale
- Avoid relying on filenames: confirmed absence with content matching of exported identifiers and package `internal/tools/image`.
- Tests from develop (`client_test.go`, `options_test.go`) were brought over; full `go test ./...` is green locally.

## Notes on adaptation
- No refactors required: files fit directly under `internal/tools/image/` matching main’s internal layout.
- No changes to public interfaces; no behavior overlap with existing code.

## Verification
- Ran `go test ./...` on the branch: all packages including `internal/tools/image` pass.

## Links
- Ports from develop mirror: `work/develop/internal/tools/image`.
- Follow-up: replace placeholder issue link with canonical tracking issue when available.