### PR TITLE
Port pre-stage built-in tools from develop (fs.list_dir, fs.stat, env.get)

### DIFF
--- a/cmd/agentcli/prestage.go
+++ b/cmd/agentcli/prestage.go
@@ -1,19 +1,22 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"os"
-	"os/exec"
-	"runtime"
-	"strings"
+    "context"
+    "encoding/json"
+    "errors"
+    "fmt"
+    "io"
+    "io/fs"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "runtime"
+    "sort"
+    "strings"
 
-	"github.com/hyperifyio/goagent/internal/oai"
-	"github.com/hyperifyio/goagent/internal/oai/prestage"
-	"github.com/hyperifyio/goagent/internal/tools"
+    "github.com/hyperifyio/goagent/internal/oai"
+    "github.com/hyperifyio/goagent/internal/oai/prestage"
+    "github.com/hyperifyio/goagent/internal/tools"
 )
 
 // dumpJSONIfDebug marshals v and prints it with a label when debug is enabled.
@@ -265,58 +268,168 @@ func runPreStage(cfg cliConfig, messages []oai.Message, stderr io.Writer) ([]oai
 
 // appendPreStageBuiltinToolOutputs executes built-in read-only pre-stage tools.
 // For now this is a no-op placeholder to keep behavior deterministic without external tools.
-func appendPreStageBuiltinToolOutputs(messages []oai.Message, assistantMsg oai.Message, cfg cliConfig) []oai.Message {
-	if len(assistantMsg.ToolCalls) == 0 {
-		return messages
-	}
-	// Execute a minimal, safe subset inline without spawning processes.
-	// Supported names: fs.read_file, os.info. Others are ignored.
-	for _, tc := range assistantMsg.ToolCalls {
-		name := strings.TrimSpace(tc.Function.Name)
-		switch name {
-		case "fs.read_file":
-			// Parse {"path":"..."}
-			var args struct {
-				Path string `json:"path"`
-			}
-			// Best-effort JSON decode; ignore on error
-			_ = json.Unmarshal([]byte(tc.Function.Arguments), &args)
-			var content string
-			if s := strings.TrimSpace(args.Path); s != "" {
-				if b, err := os.ReadFile(s); err == nil {
-					content = string(b)
-				}
-			}
-			// Build deterministic one-line JSON
-			payload, _ := json.Marshal(map[string]any{
-				"path":    strings.TrimSpace(args.Path),
-				"content": content,
-			})
-			messages = append(messages, oai.Message{
-				Role:       oai.RoleTool,
-				ToolCallID: strings.TrimSpace(tc.ID),
-				Name:       name,
-				Content:    oneLine(string(payload)),
-			})
-		case "os.info":
-			// Emit GOOS/GOARCH and process pid
-			info := map[string]any{
-				"goos":   runtime.GOOS,
-				"goarch": runtime.GOARCH,
-				"pid":    os.Getpid(),
-			}
-			payload, _ := json.Marshal(info)
-			messages = append(messages, oai.Message{
-				Role:       oai.RoleTool,
-				ToolCallID: strings.TrimSpace(tc.ID),
-				Name:       name,
-				Content:    oneLine(string(payload)),
-			})
-		default:
-			// Ignore unsupported built-ins for now
-		}
-	}
-	return messages
+func appendPreStageBuiltinToolOutputs(messages []oai.Message, assistantMsg oai.Message, _ cliConfig) []oai.Message {
+    if len(assistantMsg.ToolCalls) == 0 {
+        return messages
+    }
+    for _, tc := range assistantMsg.ToolCalls {
+        name := strings.TrimSpace(tc.Function.Name)
+        argsJSON := strings.TrimSpace(tc.Function.Arguments)
+        if argsJSON == "" {
+            argsJSON = "{}"
+        }
+        // Parse arguments into a generic map
+        var args map[string]any
+        if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+            messages = append(messages, oai.Message{Role: oai.RoleTool, Name: name, ToolCallID: tc.ID, Content: mustJSON(map[string]string{"error": "invalid arguments"})})
+            continue
+        }
+
+        switch name {
+        case "fs.read_file":
+            content, err := prepReadFile(args)
+            if err != nil {
+                messages = append(messages, oai.Message{Role: oai.RoleTool, Name: name, ToolCallID: tc.ID, Content: mustJSON(map[string]string{"error": err.Error()})})
+            } else {
+                messages = append(messages, oai.Message{Role: oai.RoleTool, Name: name, ToolCallID: tc.ID, Content: mustJSON(map[string]any{"content": content})})
+            }
+        case "fs.list_dir":
+            entries, err := prepListDir(args)
+            if err != nil {
+                messages = append(messages, oai.Message{Role: oai.RoleTool, Name: name, ToolCallID: tc.ID, Content: mustJSON(map[string]string{"error": err.Error()})})
+            } else {
+                messages = append(messages, oai.Message{Role: oai.RoleTool, Name: name, ToolCallID: tc.ID, Content: mustJSON(map[string]any{"entries": entries})})
+            }
+        case "fs.stat":
+            st, err := prepStat(args)
+            if err != nil {
+                messages = append(messages, oai.Message{Role: oai.RoleTool, Name: name, ToolCallID: tc.ID, Content: mustJSON(map[string]string{"error": err.Error()})})
+            } else {
+                messages = append(messages, oai.Message{Role: oai.RoleTool, Name: name, ToolCallID: tc.ID, Content: mustJSON(st)})
+            }
+        case "env.get":
+            key := ""
+            if kv, ok := args["key"].(string); ok {
+                key = kv
+            }
+            val := os.Getenv(strings.TrimSpace(key))
+            messages = append(messages, oai.Message{Role: oai.RoleTool, Name: name, ToolCallID: tc.ID, Content: mustJSON(map[string]string{"value": val})})
+        case "os.info":
+            messages = append(messages, oai.Message{Role: oai.RoleTool, Name: name, ToolCallID: tc.ID, Content: mustJSON(map[string]string{"goos": runtime.GOOS, "goarch": runtime.GOARCH})})
+        default:
+            // Unknown or disallowed tool names deterministically error
+            messages = append(messages, oai.Message{Role: oai.RoleTool, Name: name, ToolCallID: tc.ID, Content: mustJSON(map[string]string{"error": fmt.Sprintf("unknown tool: %s", name)})})
+        }
+    }
+    return messages
+}
+
+// mustJSON marshals v to a compact one-line JSON string. Falls back to a minimal error JSON.
+func mustJSON(v any) string {
+    b, err := json.Marshal(v)
+    if err != nil {
+        return "{\"error\":\"internal error\"}"
+    }
+    // Collapse whitespace just in case
+    s := string(b)
+    s = strings.ReplaceAll(s, "\n", " ")
+    s = strings.ReplaceAll(s, "\t", " ")
+    return strings.Join(strings.Fields(s), " ")
+}
+
+func requireRepoRelativePath(args map[string]any) (string, error) {
+    raw := ""
+    if v, ok := args["path"].(string); ok {
+        raw = v
+    }
+    if strings.TrimSpace(raw) == "" {
+        return "", fmt.Errorf("path is required")
+    }
+    // Reject absolute paths
+    if filepath.IsAbs(raw) {
+        return "", fmt.Errorf("path must be repo-relative")
+    }
+    // Clean and forbid parent traversal
+    cleaned := filepath.Clean(strings.ReplaceAll(raw, "\\", "/"))
+    if strings.HasPrefix(cleaned, "../") || cleaned == ".." {
+        return "", fmt.Errorf("path must not contain parent traversal")
+    }
+    // Resolve against current working directory (acts as repo root in tests/CLI)
+    abs, err := filepath.Abs(cleaned)
+    if err != nil {
+        return "", fmt.Errorf("resolve path: %w", err)
+    }
+    return abs, nil
+}
+
+func prepReadFile(args map[string]any) (string, error) {
+    abs, err := requireRepoRelativePath(args)
+    if err != nil {
+        return "", err
+    }
+    // Read up to a reasonable size to avoid giant outputs; 256 KiB cap
+    const capBytes = 256 * 1024
+    data, err := os.ReadFile(abs)
+    if err != nil {
+        return "", err
+    }
+    if len(data) > capBytes {
+        data = data[:capBytes]
+    }
+    // Return as UTF-8 string; lossy but sufficient for read-only inspection
+    return string(data), nil
+}
+
+type listEntry struct {
+    Name string `json:"name"`
+    Type string `json:"type"` // file|dir|other
+}
+
+func prepListDir(args map[string]any) ([]listEntry, error) {
+    abs, err := requireRepoRelativePath(args)
+    if err != nil {
+        return nil, err
+    }
+    entries, err := os.ReadDir(abs)
+    if err != nil {
+        return nil, err
+    }
+    out := make([]listEntry, 0, len(entries))
+    for _, e := range entries {
+        typ := "file"
+        if e.IsDir() {
+            typ = "dir"
+        }
+        // Detect other types best-effort
+        if !e.IsDir() {
+            if info, ierr := e.Info(); ierr == nil {
+                if (info.Mode() & fs.ModeSymlink) != 0 {
+                    typ = "other"
+                }
+            }
+        }
+        out = append(out, listEntry{Name: e.Name(), Type: typ})
+    }
+    // Deterministic order
+    sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+    return out, nil
+}
+
+type statView struct {
+    Size  int64 `json:"size"`
+    IsDir bool  `json:"is_dir"`
+}
+
+func prepStat(args map[string]any) (statView, error) {
+    abs, err := requireRepoRelativePath(args)
+    if err != nil {
+        return statView{}, err
+    }
+    fi, err := os.Stat(abs)
+    if err != nil {
+        return statView{}, err
+    }
+    return statView{Size: fi.Size(), IsDir: fi.IsDir()}, nil
 }
 
 // sanitizeToolContent maps tool output and errors to a deterministic JSON string.


### PR DESCRIPTION
## Summary
- Port functionality from develop mirror to main: execute built-in pre-stage tools when external tools are disabled.
- Implements `fs.list_dir`, `fs.stat`, and `env.get` alongside existing `fs.read_file` and `os.info`.
- Adds repo-relative path validation and deterministic JSON helpers to match develop behavior.

## How we determined it was missing
- Content comparison showed `work/develop/cmd/agentcli/prep_tools.go` contains built-in tool adapters not present in `cmd/agentcli/prestage.go` on main.
- Whole-repo search confirmed only `fs.read_file` and `os.info` behaviors existed; no `fs.list_dir`, `fs.stat`, or `env.get` handlers.
- Tests in `cmd/agentcli/tools_integration_test.go` reference pre-stage built-ins; this change aligns main with develop’s implementation.

## Implementation notes
- Expanded `appendPreStageBuiltinToolOutputs` to dispatch names and emit deterministic one-line JSON.
- Added `requireRepoRelativePath`, `prepReadFile` (capped read), `prepListDir` (typed entries, sorted), and `prepStat`.
- Kept `./work/develop` mirror read-only; adapted code to fit main’s structure.

## Risk/compat
- New code only executes under pre-stage when external tools are disabled; default remains safe and deterministic.
- All tests pass locally (`go test ./...`).

## Links
- Ports from develop mirror file: `work/develop/cmd/agentcli/prep_tools.go`
- Tracking: This ports behavior to ensure parity between main and develop.