### PR TITLE
Port resolve helpers and prep config from develop

### DIFF
--- a/internal/oai/config_prepconfig_test.go
+++ b/internal/oai/config_prepconfig_test.go
@@ -1,0 +1,10 @@
+package oai
+
+import "testing"
+
+func TestNewPrepConfig_SetsPrompt(t *testing.T) {
+    cfg := NewPrepConfig([]string{"one", "two"})
+    if cfg.Prompt != "one\n\ntwo" {
+        t.Fatalf("unexpected prompt: %q", cfg.Prompt)
+    }
+}

--- a/internal/oai/prepconfig.go
+++ b/internal/oai/prepconfig.go
@@ -1,0 +1,16 @@
+package oai
+
+// PrepConfig holds resolved configuration for the pre-stage flow.
+// Currently it includes only the prepared prompt text.
+type PrepConfig struct {
+    // Prompt is the finalized pre-stage prompt after applying overrides.
+    // When multiple prompt sources are provided, they are concatenated using
+    // JoinPrompts and stored here.
+    Prompt string
+}
+
+// NewPrepConfig constructs a PrepConfig with Prompt set to the normalized
+// concatenation of the provided parts.
+func NewPrepConfig(parts []string) PrepConfig {
+    return PrepConfig{Prompt: JoinPrompts(parts)}
+}

--- a/internal/oai/resolve_helpers.go
+++ b/internal/oai/resolve_helpers.go
@@ -1,0 +1,40 @@
+package oai
+
+import (
+    "strconv"
+    "strings"
+)
+
+// ResolveString resolves a string value with precedence:
+// flag > env > inheritFrom > default. Trims whitespace from flag and env.
+// Returns the resolved value and a source label: "flag" | "env" | "inherit" | "default".
+func ResolveString(flagValue string, envValue string, inheritFrom *string, def string) (string, string) {
+    if v := strings.TrimSpace(flagValue); v != "" {
+        return v, "flag"
+    }
+    if v := strings.TrimSpace(envValue); v != "" {
+        return v, "env"
+    }
+    if inheritFrom != nil {
+        return strings.TrimSpace(*inheritFrom), "inherit"
+    }
+    return def, "default"
+}
+
+// ResolveBool resolves a bool with precedence:
+// flag (when flagSet) > env (parseable) > inheritFrom > default.
+// Returns the resolved value and a source label.
+func ResolveBool(flagSet bool, flagValue bool, envValue string, inheritFrom *bool, def bool) (bool, string) {
+    if flagSet {
+        return flagValue, "flag"
+    }
+    if s := strings.TrimSpace(envValue); s != "" {
+        if b, err := strconv.ParseBool(s); err == nil {
+            return b, "env"
+        }
+    }
+    if inheritFrom != nil {
+        return *inheritFrom, "inherit"
+    }
+    return def, "default"
+}

--- a/internal/oai/resolve_string_bool_test.go
+++ b/internal/oai/resolve_string_bool_test.go
@@ -1,0 +1,39 @@
+package oai
+
+import "testing"
+
+func TestResolveString(t *testing.T) {
+    inherit := "inh"
+    v, src := ResolveString("flag", "", &inherit, "def")
+    if v != "flag" || src != "flag" {
+        t.Fatalf("flag precedence failed: %s %s", v, src)
+    }
+    v, src = ResolveString("", "env", &inherit, "def")
+    if v != "env" || src != "env" {
+        t.Fatalf("env precedence failed: %s %s", v, src)
+    }
+    v, src = ResolveString("", "", &inherit, "def")
+    if v != "inh" || src != "inherit" {
+        t.Fatalf("inherit precedence failed: %s %s", v, src)
+    }
+    v, src = ResolveString("", "", nil, "def")
+    if v != "def" || src != "default" {
+        t.Fatalf("default precedence failed: %s %s", v, src)
+    }
+}
+
+func TestResolveBool(t *testing.T) {
+    inh := false
+    if v, src := ResolveBool(true, true, "", &inh, false); !v || src != "flag" {
+        t.Fatalf("flag precedence failed")
+    }
+    if v, src := ResolveBool(false, false, "true", &inh, false); !v || src != "env" {
+        t.Fatalf("env precedence failed")
+    }
+    if v, src := ResolveBool(false, false, "bad", &inh, false); v != false || src != "inherit" {
+        t.Fatalf("inherit fallback failed")
+    }
+    if v, src := ResolveBool(false, false, "", nil, true); v != true || src != "default" {
+        t.Fatalf("default fallback failed")
+    }
+}


### PR DESCRIPTION
## Summary
- Ports `ResolveString`, `ResolveBool`, and `PrepConfig`/`NewPrepConfig` from the develop mirror (`work/develop`) into main.
- Content-based comparison showed these helpers/types existed only under `work/develop/internal/oai` and had no equivalents in `internal/oai` on main.
- Added focused tests adapted from develop to establish expected behavior; implemented minimal code to integrate with main’s current `JoinPrompts` and prompt resolution layout.

## Details
- Verified absence in main via repository-wide search for exported identifiers and types; only `ResolveInt`/`ResolveDuration` and prompt helpers existed.
- Confirmed presence in develop under:
  - `work/develop/internal/oai/resolve.go` (ResolveString/ResolveBool)
  - `work/develop/internal/oai/config.go` (PrepConfig and NewPrepConfig)
- Implementations were adapted to main’s structure (e.g., using `internal/oai/prompt_resolve.go` `JoinPrompts`). No changes to main or develop branches themselves.

## Testing
- New tests in `internal/oai` cover precedence rules and prompt joining.
- `go test ./...` passes locally.

## Notes
- This ports functionality without altering branch pointers; `work/develop` remains read-only.
- If other resolve helpers from develop are desired, we can port in follow-ups.