### PR TITLE
Port CLI tests from develop; fix duration precedence

### DIFF
--- a/cmd/agentcli/cli_docs_sync_test.go
+++ b/cmd/agentcli/cli_docs_sync_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestCLIReference_IncludesAllFlagsFromHelp ensures that docs/reference/cli-reference.md
+// includes every flag token that appears in the CLI's built-in help output.
+func TestCLIReference_IncludesAllFlagsFromHelp(t *testing.T) {
+	// Render help text via the same function used by the CLI for --help/-h/help.
+	var b strings.Builder
+	printUsage(&b)
+	help := b.String()
+
+	// Extract flag tokens from help output. Lines start with two spaces, a hyphen, then the flag.
+	var flags []string
+	for _, line := range strings.Split(help, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.HasPrefix(line, "  -") || strings.HasPrefix(line, "  --") {
+			// Take the first whitespace-separated token as the flag token (e.g., -prompt, --version)
+			fields := strings.Fields(line)
+			if len(fields) > 0 {
+				token := fields[0]
+				// Normalize trailing punctuation if any
+				token = strings.TrimRight(token, ":")
+				flags = append(flags, token)
+			}
+		}
+	}
+	if len(flags) == 0 {
+		t.Fatalf("no flags parsed from help; help was:\n%s", help)
+	}
+
+	// Load CLI reference doc. Resolve relative to this test file's directory for robustness.
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("runtime.Caller failed")
+	}
+	thisDir := filepath.Dir(thisFile)
+	// Repo root is the parent of the parent (.. of cmd/agentcli => repo root)
+	repoRoot := filepath.Dir(filepath.Dir(thisDir))
+	tryPaths := []string{
+		filepath.Join(repoRoot, "docs", "reference", "cli-reference.md"),
+		filepath.Join(repoRoot, "README.md"), // fallback so test gives a clearer error if mislocated
+	}
+	var data []byte
+	var err error
+	var usedPath string
+	for _, p := range tryPaths {
+		if b, e := os.ReadFile(p); e == nil {
+			data, err, usedPath = b, nil, p
+			break
+		} else {
+			err = e
+		}
+	}
+	if data == nil {
+		t.Fatalf("failed to read CLI reference doc from %v: last error: %v", tryPaths, err)
+	}
+	_ = usedPath // retained for potential future diagnostics
+
+	doc := string(data)
+
+	// For each flag token from help, assert that the doc mentions it.
+	// We look for the raw token (e.g., "-prompt") to keep this simple and robust to formatting.
+	for _, token := range flags {
+		// The version line in help is "--version | -version". Ensure both variants are present in docs.
+		if token == "--version" {
+			if !strings.Contains(doc, "--version") || !strings.Contains(doc, "-version") {
+				t.Fatalf("docs missing one of version tokens: --version or -version; flags=%v", flags)
+			}
+			continue
+		}
+		// Skip duplicate check for -version since it is covered by the --version case.
+		if token == "-version" {
+			continue
+		}
+		if !strings.Contains(doc, token) {
+			t.Fatalf("docs/reference/cli-reference.md missing flag token %q from help; help line present, doc needs update", token)
+		}
+	}
+}

--- a/cmd/agentcli/compat_test.go
+++ b/cmd/agentcli/compat_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestLegacyPrintConfigDefaults_NoNewFlags ensures that a minimal invocation
+// without new flags produces the same resolved config baseline.
+func TestLegacyPrintConfigDefaults_NoNewFlags(t *testing.T) {
+	// Ensure env does not influence defaults
+	t.Setenv("OAI_BASE_URL", "")
+	t.Setenv("OAI_MODEL", "")
+	t.Setenv("OAI_HTTP_TIMEOUT", "")
+	t.Setenv("OAI_IMAGE_MODEL", "")
+
+	var out, err bytes.Buffer
+	code := cliMain([]string{"-prompt", "p", "-print-config"}, &out, &err)
+	if code != 0 {
+		t.Fatalf("print-config exit=%d, stderr=%s", code, err.String())
+	}
+	// Parse JSON
+	var payload map[string]any
+	if jerr := json.Unmarshal(out.Bytes(), &payload); jerr != nil {
+		t.Fatalf("unmarshal print-config: %v; got %s", jerr, out.String())
+	}
+	// Top-level expectations
+	if got, ok := payload["model"].(string); !ok || got != "oss-gpt-20b" {
+		t.Fatalf("model=%v; want oss-gpt-20b", payload["model"])
+	}
+	if got, ok := payload["baseURL"].(string); !ok || got != "https://api.openai.com/v1" {
+		t.Fatalf("baseURL=%v; want https://api.openai.com/v1", payload["baseURL"])
+	}
+	if got, ok := payload["httpTimeout"].(string); !ok || got != "30s" {
+		t.Fatalf("httpTimeout=%v; want 30s", payload["httpTimeout"])
+	}
+	// Image block expectations
+	img, ok := payload["image"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing image block in print-config")
+	}
+	if got, ok := img["model"].(string); !ok || got != "gpt-image-1" {
+		t.Fatalf("image.model=%v; want gpt-image-1", img["model"])
+	}
+}
+
+func TestConflictingPromptSources_ErrorMessage(t *testing.T) {
+	var out, err bytes.Buffer
+	code := cliMain([]string{"-prompt", "p", "-prompt-file", os.DevNull}, &out, &err)
+	if code != 2 {
+		t.Fatalf("exit=%d; want 2", code)
+	}
+	if !strings.Contains(err.String(), "-prompt and -prompt-file are mutually exclusive") {
+		t.Fatalf("stderr did not contain conflict message; got: %s", err.String())
+	}
+}
+
+func TestConflictingSystemSources_ErrorMessage(t *testing.T) {
+	var out, err bytes.Buffer
+	// Provide both -system (non-default) and -system-file
+	code := cliMain([]string{"-prompt", "p", "-system", "X", "-system-file", os.DevNull}, &out, &err)
+	if code != 2 {
+		t.Fatalf("exit=%d; want 2", code)
+	}
+	if !strings.Contains(err.String(), "-system and -system-file are mutually exclusive") {
+		t.Fatalf("stderr did not contain system conflict message; got: %s", err.String())
+	}
+}
+
+func TestLoadMessagesWithPromptConflict_ErrorMessage(t *testing.T) {
+	var out, err bytes.Buffer
+	code := cliMain([]string{"-load-messages", os.DevNull, "-prompt", "p"}, &out, &err)
+	if code != 2 {
+		t.Fatalf("exit=%d; want 2", code)
+	}
+	if !strings.Contains(err.String(), "-load-messages cannot be combined with -prompt or -prompt-file") {
+		t.Fatalf("stderr did not contain load/prompt conflict message; got: %s", err.String())
+	}
+}
+
+func TestSaveAndLoadMessagesConflict_ErrorMessage(t *testing.T) {
+	var out, err bytes.Buffer
+	code := cliMain([]string{"-prompt", "p", "-save-messages", os.DevNull, "-load-messages", os.DevNull}, &out, &err)
+	if code != 2 {
+		t.Fatalf("exit=%d; want 2", code)
+	}
+	if !strings.Contains(err.String(), "-save-messages and -load-messages are mutually exclusive") {
+		t.Fatalf("stderr did not contain save/load conflict message; got: %s", err.String())
+	}
+}

--- a/cmd/agentcli/flags_test.go
+++ b/cmd/agentcli/flags_test.go
@@ -1,0 +1,493 @@
+//nolint:errcheck // Tests intentionally allow some unchecked errors for pipe/env helpers.
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestParseFlags_SystemAndSystemFile_MutuallyExclusive ensures providing both
+// -system (non-default) and -system-file results in exit code 2 from parseFlags.
+func TestParseFlags_SystemAndSystemFile_MutuallyExclusive(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"agentcli.test", "-system", "custom", "-system-file", "sys.txt", "-prompt", "p"}
+
+	_, code := parseFlags()
+	if code != 2 {
+		t.Fatalf("parseFlags exit = %d; want 2 (mutual exclusion)", code)
+	}
+}
+
+// TestParseFlags_PrepSystem_Exclusivity ensures -prep-system and -prep-system-file are mutually exclusive.
+func TestParseFlags_PrepSystem_Exclusivity(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"agentcli.test", "-prompt", "p", "-prep-system", "X", "-prep-system-file", "-"}
+	_, code := parseFlags()
+	if code != 2 {
+		t.Fatalf("parseFlags exit = %d; want 2 (mutual exclusion)", code)
+	}
+}
+
+// TestPrepSystem_EnvAndFlagPrecedence ensures env is used when flags unset and flag overrides env.
+func TestPrepSystem_EnvAndFlagPrecedence(t *testing.T) {
+	t.Setenv("OAI_PREP_SYSTEM", "ENV_SYS")
+	t.Setenv("OAI_PREP_SYSTEM_FILE", "")
+	// When flags unset, env should populate cfg.prepSystem
+	orig := os.Args
+	defer func() { os.Args = orig }()
+	os.Args = []string{"agentcli.test", "-prompt", "p"}
+	cfg, code := parseFlags()
+	if code != 0 {
+		t.Fatalf("parseFlags exit=%d; want 0", code)
+	}
+	if strings.TrimSpace(cfg.prepSystem) != "ENV_SYS" {
+		t.Fatalf("prepSystem=%q; want ENV_SYS", cfg.prepSystem)
+	}
+	// Flag should override env
+	os.Args = []string{"agentcli.test", "-prompt", "p", "-prep-system", "FLAG_SYS"}
+	cfg, code = parseFlags()
+	if code != 0 {
+		t.Fatalf("parseFlags exit=%d; want 0", code)
+	}
+	if strings.TrimSpace(cfg.prepSystem) != "FLAG_SYS" {
+		t.Fatalf("prepSystem=%q; want FLAG_SYS", cfg.prepSystem)
+	}
+}
+
+// TestParseFlags_PromptAndPromptFile_MutuallyExclusive ensures providing both
+// -prompt and -prompt-file results in exit code 2 from parseFlags.
+func TestParseFlags_PromptAndPromptFile_MutuallyExclusive(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"agentcli.test", "-prompt", "inline", "-prompt-file", "p.txt"}
+
+	_, code := parseFlags()
+	if code != 2 {
+		t.Fatalf("parseFlags exit = %d; want 2 (mutual exclusion)", code)
+	}
+}
+
+// TestResolveMaybeFile_InlinePreferred returns inline when filePath empty.
+func TestResolveMaybeFile_InlinePreferred(t *testing.T) {
+	got, err := resolveMaybeFile("inline", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "inline" {
+		t.Fatalf("got %q; want %q", got, "inline")
+	}
+}
+
+// TestResolveMaybeFile_File reads content from a real file.
+func TestResolveMaybeFile_File(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "p.txt")
+	if err := os.WriteFile(path, []byte("from-file"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	got, err := resolveMaybeFile("inline-ignored", path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "from-file" {
+		t.Fatalf("got %q; want %q", got, "from-file")
+	}
+}
+
+// TestResolveMaybeFile_STDIN reads content when filePath is "-".
+func TestResolveMaybeFile_STDIN(t *testing.T) {
+	// Save and restore os.Stdin
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+
+	r := bytes.NewBufferString("from-stdin")
+	// Create a pipe and write contents so io.ReadAll can consume it as Stdin
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	// Write and close writer
+	if _, err := pw.Write(r.Bytes()); err != nil {
+		t.Fatalf("write to pipe: %v", err)
+	}
+	_ = pw.Close()
+	os.Stdin = pr
+
+	got, err := resolveMaybeFile("ignored", "-")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(got) != "from-stdin" {
+		t.Fatalf("got %q; want %q", got, "from-stdin")
+	}
+}
+
+// TestResolveDeveloperMessages_Order ensures files are read first (in order),
+// followed by inline -developer values (in order).
+func TestResolveDeveloperMessages_Order(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "dev1.txt")
+	f2 := filepath.Join(dir, "dev2.txt")
+	if err := os.WriteFile(f1, []byte("file-1"), 0o644); err != nil {
+		t.Fatalf("write f1: %v", err)
+	}
+	if err := os.WriteFile(f2, []byte("file-2"), 0o644); err != nil {
+		t.Fatalf("write f2: %v", err)
+	}
+
+	devs, err := resolveDeveloperMessages([]string{"inline-1", "inline-2"}, []string{f1, f2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"file-1", "file-2", "inline-1", "inline-2"}
+	if len(devs) != len(want) {
+		t.Fatalf("len(devs)=%d; want %d", len(devs), len(want))
+	}
+	for i := range want {
+		if strings.TrimSpace(devs[i]) != want[i] {
+			t.Fatalf("devs[%d]=%q; want %q", i, devs[i], want[i])
+		}
+	}
+}
+
+// TestResolveDeveloperMessages_STDIN ensures a "-" entry is read from stdin.
+func TestResolveDeveloperMessages_STDIN(t *testing.T) {
+	// Save and restore os.Stdin
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+
+	// Prepare stdin data
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := pw.Write([]byte("dev-stdin")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = pw.Close()
+	os.Stdin = pr
+
+	devs, err := resolveDeveloperMessages([]string{"inline"}, []string{"-"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(devs) != 2 {
+		t.Fatalf("len(devs)=%d; want 2", len(devs))
+	}
+	if strings.TrimSpace(devs[0]) != "dev-stdin" {
+		t.Fatalf("first dev from stdin = %q; want %q", devs[0], "dev-stdin")
+	}
+	if strings.TrimSpace(devs[1]) != "inline" {
+		t.Fatalf("second dev inline = %q; want %q", devs[1], "inline")
+	}
+}
+
+// TestHelpContainsRoleFlags ensures help output mentions the role flags, as a smoke test.
+func TestHelpContainsRoleFlags(t *testing.T) {
+	var b strings.Builder
+	printUsage(&b)
+	help := b.String()
+	for _, token := range []string{"-developer", "-developer-file", "-prompt-file", "-system-file"} {
+		if !strings.Contains(help, token) {
+			t.Fatalf("help missing %s token; help=\n%s", token, help)
+		}
+	}
+}
+
+// TestImageParamDefaultsAndEnvAndFlags verifies precedence and defaults for image param pass-throughs.
+//
+//nolint:gocyclo // Intentional multi-branch table-style assertions for env/flag precedence in one test.
+func TestImageParamDefaultsAndEnvAndFlags(t *testing.T) {
+	// Clear possibly impacting envs
+	t.Setenv("OAI_IMAGE_N", "")
+	t.Setenv("OAI_IMAGE_SIZE", "")
+	t.Setenv("OAI_IMAGE_QUALITY", "")
+	t.Setenv("OAI_IMAGE_STYLE", "")
+	t.Setenv("OAI_IMAGE_RESPONSE_FORMAT", "")
+	t.Setenv("OAI_IMAGE_TRANSPARENT_BACKGROUND", "")
+
+	t.Run("defaults when neither flags nor env", func(t *testing.T) { //nolint:tparallel // serial to avoid env races
+		orig := os.Args
+		defer func() { os.Args = orig }()
+		os.Args = []string{"agentcli.test", "-prompt", "p"}
+		cfg, code := parseFlags()
+		if code != 0 {
+			t.Fatalf("parseFlags exit=%d; want 0", code)
+		}
+		if cfg.imageN != 1 || cfg.imageSize != "1024x1024" || cfg.imageQuality != "standard" || cfg.imageStyle != "natural" || cfg.imageResponseFormat != "url" || cfg.imageTransparentBackground != false {
+			t.Fatalf("defaults mismatch: n=%d size=%s quality=%s style=%s resp=%s transparent=%v", cfg.imageN, cfg.imageSize, cfg.imageQuality, cfg.imageStyle, cfg.imageResponseFormat, cfg.imageTransparentBackground)
+		}
+	})
+
+	t.Run("env applies when flags unset", func(t *testing.T) { //nolint:tparallel
+			t.Setenv("OAI_IMAGE_N", "3")
+			t.Setenv("OAI_IMAGE_SIZE", "512x512")
+			t.Setenv("OAI_IMAGE_QUALITY", "hd")
+			t.Setenv("OAI_IMAGE_STYLE", "vivid")
+			t.Setenv("OAI_IMAGE_RESPONSE_FORMAT", "b64_json")
+			t.Setenv("OAI_IMAGE_TRANSPARENT_BACKGROUND", "true")
+			orig := os.Args
+			defer func() { os.Args = orig }()
+			os.Args = []string{"agentcli.test", "-prompt", "p"}
+			cfg, code := parseFlags()
+			if code != 0 {
+				t.Fatalf("parseFlags exit=%d; want 0", code)
+			}
+			if cfg.imageN != 3 || cfg.imageSize != "512x512" || cfg.imageQuality != "hd" || cfg.imageStyle != "vivid" || cfg.imageResponseFormat != "b64_json" || cfg.imageTransparentBackground != true {
+				t.Fatalf("env mismatch: n=%d size=%s quality=%s style=%s resp=%s transparent=%v", cfg.imageN, cfg.imageSize, cfg.imageQuality, cfg.imageStyle, cfg.imageResponseFormat, cfg.imageTransparentBackground)
+			}
+		})
+
+	t.Run("flags override env", func(t *testing.T) { //nolint:tparallel
+			t.Setenv("OAI_IMAGE_N", "2")
+			t.Setenv("OAI_IMAGE_SIZE", "256x256")
+			t.Setenv("OAI_IMAGE_QUALITY", "standard")
+			t.Setenv("OAI_IMAGE_STYLE", "natural")
+			t.Setenv("OAI_IMAGE_RESPONSE_FORMAT", "url")
+			t.Setenv("OAI_IMAGE_TRANSPARENT_BACKGROUND", "false")
+			orig := os.Args
+			defer func() { os.Args = orig }()
+			os.Args = []string{"agentcli.test", "-prompt", "p", "-image-n", "4", "-image-size", "640x640", "-image-quality", "hd", "-image-style", "vivid", "-image-response-format", "b64_json", "-image-transparent-background", "true"}
+			cfg, code := parseFlags()
+			if code != 0 {
+				t.Fatalf("parseFlags exit=%d; want 0", code)
+			}
+			if cfg.imageN != 4 || cfg.imageSize != "640x640" || cfg.imageQuality != "hd" || cfg.imageStyle != "vivid" || cfg.imageResponseFormat != "b64_json" || cfg.imageTransparentBackground != true {
+				t.Fatalf("flags mismatch: n=%d size=%s quality=%s style=%s resp=%s transparent=%v", cfg.imageN, cfg.imageSize, cfg.imageQuality, cfg.imageStyle, cfg.imageResponseFormat, cfg.imageTransparentBackground)
+			}
+		})
+}
+
+// TestImageModelFlagPrecedence verifies precedence flag > env > default for -image-model.
+func TestImageModelFlagPrecedence(t *testing.T) {
+	t.Run("default when neither flags nor env", func(t *testing.T) { //nolint:tparallel
+		t.Setenv("OAI_IMAGE_MODEL", "")
+		orig := os.Args
+		defer func() { os.Args = orig }()
+		os.Args = []string{"agentcli.test", "-prompt", "p"}
+		cfg, code := parseFlags()
+		if code != 0 {
+			t.Fatalf("parseFlags exit=%d; want 0", code)
+		}
+		if cfg.imageModel != "gpt-image-1" {
+			t.Fatalf("imageModel=%q; want gpt-image-1", cfg.imageModel)
+		}
+	})
+
+	t.Run("env applies when flag unset", func(t *testing.T) { //nolint:tparallel
+			t.Setenv("OAI_IMAGE_MODEL", "env-model")
+			orig := os.Args
+			defer func() { os.Args = orig }()
+			os.Args = []string{"agentcli.test", "-prompt", "p"}
+			cfg, code := parseFlags()
+			if code != 0 {
+				t.Fatalf("parseFlags exit=%d; want 0", code)
+			}
+			if cfg.imageModel != "env-model" {
+				t.Fatalf("imageModel=%q; want env-model", cfg.imageModel)
+			}
+		})
+
+	t.Run("flags override env", func(t *testing.T) { //nolint:tparallel
+			t.Setenv("OAI_IMAGE_MODEL", "env-model")
+			orig := os.Args
+			defer func() { os.Args = orig }()
+			os.Args = []string{"agentcli.test", "-prompt", "p", "-image-model", "flag-model"}
+			cfg, code := parseFlags()
+			if code != 0 {
+				t.Fatalf("parseFlags exit=%d; want 0", code)
+			}
+			if cfg.imageModel != "flag-model" {
+				t.Fatalf("imageModel=%q; want flag-model", cfg.imageModel)
+			}
+		})
+}
+
+// TestPrintConfig_IncludesImageParams verifies print-config output reflects resolved image params.
+func TestPrintConfig_IncludesImageParams(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+	os.Args = []string{"agentcli.test", "-prompt", "p", "-image-n", "2", "-image-size", "512x512", "-image-quality", "hd", "-image-style", "vivid", "-image-response-format", "b64_json", "-image-transparent-background", "true", "-print-config"}
+	var out bytes.Buffer
+	// parse then print
+	cfg, code := parseFlags()
+	if code != 0 {
+		t.Fatalf("parseFlags exit=%d; want 0", code)
+	}
+	exit := printResolvedConfig(cfg, &out)
+	if exit != 0 {
+		t.Fatalf("printResolvedConfig exit=%d; want 0", exit)
+	}
+	s := out.String()
+	for _, token := range []string{
+		"\"image\"",
+		"\"n\": 2",
+		"\"size\": \"512x512\"",
+		"\"quality\": \"hd\"",
+		"\"style\": \"vivid\"",
+		"\"response_format\": \"b64_json\"",
+		"\"transparent_background\": true",
+	} {
+		if !strings.Contains(s, token) {
+			t.Fatalf("print-config missing %s in output: %s", token, s)
+		}
+	}
+}
+
+// Avoid unused imports on some platforms
+var _ = runtime.GOOS
+
+// TestHTTPRetryPrecedence verifies precedence and defaults for -http-retries and -http-retry-backoff.
+func TestHTTPRetryPrecedence(t *testing.T) {
+	// Save and restore env using t.Setenv for cleanliness
+	t.Setenv("OAI_HTTP_RETRIES", "")
+	t.Setenv("OAI_HTTP_RETRY_BACKOFF", "")
+
+	t.Run("defaults when neither flags nor env", func(t *testing.T) {
+		orig := os.Args
+		defer func() { os.Args = orig }()
+		os.Args = []string{"agentcli.test", "-prompt", "p"}
+		cfg, code := parseFlags()
+		if code != 0 {
+			t.Fatalf("parseFlags exit=%d; want 0", code)
+		}
+		if cfg.httpRetries != 2 {
+			t.Fatalf("httpRetries=%d; want 2", cfg.httpRetries)
+		}
+		if cfg.httpBackoff.String() != "500ms" {
+			t.Fatalf("httpBackoff=%s; want 500ms", cfg.httpBackoff)
+		}
+	})
+
+	t.Run("env applies when flags unset", func(t *testing.T) {
+			t.Setenv("OAI_HTTP_RETRIES", "5")
+			t.Setenv("OAI_HTTP_RETRY_BACKOFF", "750ms")
+			orig := os.Args
+			defer func() { os.Args = orig }()
+			os.Args = []string{"agentcli.test", "-prompt", "p"}
+			cfg, code := parseFlags()
+			if code != 0 {
+				t.Fatalf("parseFlags exit=%d; want 0", code)
+			}
+			if cfg.httpRetries != 5 {
+				t.Fatalf("httpRetries=%d; want 5", cfg.httpRetries)
+			}
+			if cfg.httpBackoff.String() != "750ms" {
+				t.Fatalf("httpBackoff=%s; want 750ms", cfg.httpBackoff)
+			}
+		})
+
+	t.Run("flags override env", func(t *testing.T) {
+			t.Setenv("OAI_HTTP_RETRIES", "7")
+			t.Setenv("OAI_HTTP_RETRY_BACKOFF", "900ms")
+			orig := os.Args
+			defer func() { os.Args = orig }()
+			os.Args = []string{"agentcli.test", "-prompt", "p", "-http-retries", "3", "-http-retry-backoff", "1s"}
+			cfg, code := parseFlags()
+			if code != 0 {
+				t.Fatalf("parseFlags exit=%d; want 0", code)
+			}
+			if cfg.httpRetries != 3 {
+				t.Fatalf("httpRetries=%d; want 3", cfg.httpRetries)
+			}
+			if cfg.httpBackoff.String() != "1s" {
+				t.Fatalf("httpBackoff=%s; want 1s", cfg.httpBackoff)
+			}
+		})
+
+	t.Run("explicit zero via flags retains zero", func(t *testing.T) {
+		orig := os.Args
+		defer func() { os.Args = orig }()
+		os.Args = []string{"agentcli.test", "-prompt", "p", "-http-retries", "0", "-http-retry-backoff", "0"}
+		cfg, code := parseFlags()
+		if code != 0 {
+			t.Fatalf("parseFlags exit=%d; want 0", code)
+		}
+		if cfg.httpRetries != 0 {
+			t.Fatalf("httpRetries=%d; want 0", cfg.httpRetries)
+		}
+		if cfg.httpBackoff != 0 {
+			t.Fatalf("httpBackoff=%s; want 0", cfg.httpBackoff)
+		}
+	})
+}
+
+// TestImageHTTPKnobsPrecedence verifies precedence and inheritance for image HTTP knobs.
+func TestImageHTTPKnobsPrecedence(t *testing.T) {
+	t.Run("defaults inherit from main when neither flags nor env", func(t *testing.T) {
+		// Clear envs that might affect defaults
+		t.Setenv("OAI_IMAGE_HTTP_TIMEOUT", "")
+		t.Setenv("OAI_IMAGE_HTTP_RETRIES", "")
+		t.Setenv("OAI_IMAGE_HTTP_RETRY_BACKOFF", "")
+		t.Setenv("OAI_HTTP_TIMEOUT", "")
+		t.Setenv("OAI_HTTP_RETRIES", "")
+		t.Setenv("OAI_HTTP_RETRY_BACKOFF", "")
+
+		orig := os.Args
+		defer func() { os.Args = orig }()
+		os.Args = []string{"agentcli.test", "-prompt", "p"}
+		cfg, code := parseFlags()
+		if code != 0 {
+			t.Fatalf("parseFlags exit=%d; want 0", code)
+		}
+		if cfg.imageHTTPTimeout != cfg.httpTimeout {
+			t.Fatalf("imageHTTPTimeout=%s; want inherit %s", cfg.imageHTTPTimeout, cfg.httpTimeout)
+		}
+		if cfg.imageHTTPRetries != cfg.httpRetries {
+			t.Fatalf("imageHTTPRetries=%d; want inherit %d", cfg.imageHTTPRetries, cfg.httpRetries)
+		}
+		if cfg.imageHTTPBackoff != cfg.httpBackoff {
+			t.Fatalf("imageHTTPBackoff=%s; want inherit %s", cfg.imageHTTPBackoff, cfg.httpBackoff)
+		}
+	})
+
+	t.Run("env applies when flags unset", func(t *testing.T) {
+			t.Setenv("OAI_IMAGE_HTTP_TIMEOUT", "7s")
+			t.Setenv("OAI_IMAGE_HTTP_RETRIES", "9")
+			t.Setenv("OAI_IMAGE_HTTP_RETRY_BACKOFF", "1.5s")
+			orig := os.Args
+			defer func() { os.Args = orig }()
+			os.Args = []string{"agentcli.test", "-prompt", "p"}
+			cfg, code := parseFlags()
+			if code != 0 {
+				t.Fatalf("parseFlags exit=%d; want 0", code)
+			}
+			if cfg.imageHTTPTimeout.String() != "7s" {
+				t.Fatalf("imageHTTPTimeout=%s; want 7s", cfg.imageHTTPTimeout)
+			}
+			if cfg.imageHTTPRetries != 9 {
+				t.Fatalf("imageHTTPRetries=%d; want 9", cfg.imageHTTPRetries)
+			}
+			if cfg.imageHTTPBackoff.String() != "1.5s" {
+				t.Fatalf("imageHTTPBackoff=%s; want 1.5s", cfg.imageHTTPBackoff)
+			}
+		})
+
+	t.Run("flags override env", func(t *testing.T) {
+			t.Setenv("OAI_IMAGE_HTTP_TIMEOUT", "7s")
+			t.Setenv("OAI_IMAGE_HTTP_RETRIES", "9")
+			t.Setenv("OAI_IMAGE_HTTP_RETRY_BACKOFF", "1.5s")
+			orig := os.Args
+			defer func() { os.Args = orig }()
+			os.Args = []string{"agentcli.test", "-prompt", "p", "-image-http-timeout", "3s", "-image-http-retries", "5", "-image-http-retry-backoff", "1s"}
+			cfg, code := parseFlags()
+			if code != 0 {
+				t.Fatalf("parseFlags exit=%d; want 0", code)
+			}
+			if cfg.imageHTTPTimeout.String() != "3s" {
+				t.Fatalf("imageHTTPTimeout=%s; want 3s", cfg.imageHTTPTimeout)
+			}
+			if cfg.imageHTTPRetries != 5 {
+				t.Fatalf("imageHTTPRetries=%d; want 5", cfg.imageHTTPRetries)
+			}
+			if cfg.imageHTTPBackoff.String() != "1s" {
+				t.Fatalf("imageHTTPBackoff=%s; want 1s", cfg.imageHTTPBackoff)
+			}
+		})
+}

--- a/cmd/agentcli/gpt5_mock_smoke_test.go
+++ b/cmd/agentcli/gpt5_mock_smoke_test.go
@@ -1,0 +1,134 @@
+//nolint:errcheck // Tests intentionally ignore some error returns for brevity; behavior validated via assertions.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	oai "github.com/hyperifyio/goagent/internal/oai"
+)
+
+// TestGPT5_MockSmoke_DefaultTemperature asserts that when targeting a GPT-5
+// model with no sampling flags, the request includes temperature 1.0 by default.
+// It uses a mock OpenAI-compatible endpoint to capture the request payload.
+func TestGPT5_MockSmoke_DefaultTemperature(t *testing.T) {
+	var seen oai.ChatCompletionsRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&seen); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(oai.ChatCompletionsResponse{Choices: []oai.ChatCompletionsResponseChoice{{Message: oai.Message{Role: oai.RoleAssistant, Content: "ok"}}}})
+	}))
+	defer srv.Close()
+
+	var outBuf, errBuf bytes.Buffer
+	code := cliMain([]string{
+		"-prompt", "Say ok",
+		"-base-url", srv.URL,
+		"-model", "gpt-5",
+		"-max-steps", "1",
+	}, &outBuf, &errBuf)
+	if code != 0 {
+		t.Fatalf("cli exit=%d stderr=%s", code, errBuf.String())
+	}
+	if seen.Temperature == nil || *seen.Temperature != 1.0 {
+		if seen.Temperature == nil {
+			t.Fatalf("expected temperature in request; want 1.0")
+		}
+		t.Fatalf("temperature got %v want 1.0", *seen.Temperature)
+	}
+}
+
+// TestGPT5_MockSmoke_ReasoningControlsIndependence simulates toggling vendor-specific
+// reasoning controls via environment variables and verifies temperature remains 1.0.
+// The agent currently ignores these envs by design; this test protects independence.
+func TestGPT5_MockSmoke_ReasoningControlsIndependence(t *testing.T) {
+	// Save and restore environment variables used in this test
+	save := func(k string) (string, bool) { v, ok := os.LookupEnv(k); return v, ok }
+	restore := func(k, v string, ok bool) {
+		if ok {
+			_ = os.Setenv(k, v)
+		} else {
+			_ = os.Unsetenv(k)
+		}
+	}
+
+	// First run: baseline
+	var baseline oai.ChatCompletionsRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req oai.ChatCompletionsRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		// On first call record baseline; on second call record override
+		if baseline.Model == "" {
+			baseline = req
+		} else {
+			// Overwrite baseline for clarity in failure messages
+			baseline = req
+		}
+		_ = json.NewEncoder(w).Encode(oai.ChatCompletionsResponse{Choices: []oai.ChatCompletionsResponseChoice{{Message: oai.Message{Role: oai.RoleAssistant, Content: "ok"}}}})
+	}))
+	defer srv.Close()
+
+	var out1, err1 bytes.Buffer
+	code := cliMain([]string{"-prompt", "x", "-base-url", srv.URL, "-model", "gpt-5", "-max-steps", "1"}, &out1, &err1)
+	if code != 0 {
+		t.Fatalf("baseline exit=%d err=%s", code, err1.String())
+	}
+	if baseline.Temperature == nil || *baseline.Temperature != 1.0 {
+		t.Fatalf("baseline temperature got %v want 1.0", ptrToString(baseline.Temperature))
+	}
+
+	// Second run: toggle hypothetical reasoning controls via env vars
+	v0, ok0 := save("GPT5_VERBOSITY")
+	v1, ok1 := save("GPT5_REASONING_EFFORT")
+	defer restore("GPT5_VERBOSITY", v0, ok0)
+	defer restore("GPT5_REASONING_EFFORT", v1, ok1)
+	_ = os.Setenv("GPT5_VERBOSITY", "high")
+	_ = os.Setenv("GPT5_REASONING_EFFORT", "medium")
+
+	var seen oai.ChatCompletionsRequest
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&seen); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(oai.ChatCompletionsResponse{Choices: []oai.ChatCompletionsResponseChoice{{Message: oai.Message{Role: oai.RoleAssistant, Content: "ok"}}}})
+	}))
+	defer srv2.Close()
+
+	var out2, err2 bytes.Buffer
+	code = cliMain([]string{"-prompt", "x", "-base-url", srv2.URL, "-model", "gpt-5", "-max-steps", "1"}, &out2, &err2)
+	if code != 0 {
+		t.Fatalf("env-toggle exit=%d err=%s", code, err2.String())
+	}
+	if seen.Temperature == nil || *seen.Temperature != 1.0 {
+		t.Fatalf("with reasoning envs, temperature got %v want 1.0", ptrToString(seen.Temperature))
+	}
+}
+
+func ptrToString(p *float64) string {
+	if p == nil {
+		return "<nil>"
+	}
+	// avoid fmt import; simple formatting
+	s := strings.TrimRight(strings.TrimRight(jsonNumber(*p), "0"), ".")
+	if s == "" {
+		return "0"
+	}
+	return s
+}
+
+// jsonNumber renders a float with JSON rules for test messages.
+func jsonNumber(f float64) string {
+	b, _ := json.Marshal(f)
+	return string(b)
+}

--- a/cmd/agentcli/help_test.go
+++ b/cmd/agentcli/help_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestHelpSnapshot_ContainsAllExpectedTokens asserts that the built-in help output
+// contains all critical flags and key phrases (inheritance, conflicts, defaults).
+// This guards against accidental drift in help documentation.
+func TestHelpSnapshot_ContainsAllExpectedTokens(t *testing.T) {
+	var b strings.Builder
+	printUsage(&b)
+	help := b.String()
+
+	// Minimal sanity checks
+	for _, token := range []string{
+		"agentcli —",
+		"Usage:",
+		"precedence: flag > env > default",
+	} {
+		if !strings.Contains(help, token) {
+			t.Fatalf("help missing required token %q; help=\n%s", token, help)
+		}
+	}
+
+	// Flags to assert are documented in help
+	flags := []string{
+		"-prompt string",
+		"-tools string",
+		"-system string",
+		"-system-file string",
+		"-developer string",
+		"-developer-file string",
+		"-prompt-file string",
+		"-base-url string",
+		"-api-key string",
+		"-model string",
+		"-max-steps int",
+		"-timeout duration",
+		"-http-timeout duration",
+		"-prep-http-timeout duration",
+		"-tool-timeout duration",
+		"-http-retries int",
+		"-http-retry-backoff duration",
+		"-image-base-url string",
+		"-image-model string",
+		"-image-api-key string",
+		"-image-http-timeout duration",
+		"-image-http-retries int",
+		"-image-http-retry-backoff duration",
+		"-temp float",
+		"-top-p float",
+		"-prep-profile string",
+		"-prep-model string",
+		"-prep-base-url string",
+		"-prep-api-key string",
+		"-prep-http-retries int",
+		"-prep-http-retry-backoff duration",
+		"-prep-temp float",
+		"-prep-top-p float",
+		"-prep-system string",
+		"-prep-system-file string",
+		"-image-n int",
+		"-image-size string",
+		"-image-quality string",
+		"-image-style string",
+		"-image-response-format string",
+		"-image-transparent-background",
+		"-debug",
+		"-verbose",
+		"-quiet",
+		"-prep-tools-allow-external",
+		"-prep-cache-bust",
+		"-prep-tools string",
+		"-prep-dry-run",
+		"-print-messages",
+		"-stream-final",
+		"-channel-route",
+		"-save-messages string",
+		"-load-messages string",
+		"-prep-enabled",
+		"-capabilities",
+		"-print-config",
+		"-dry-run",
+		"-state-dir string",
+		"-state-scope string",
+		"-state-refine",
+		"-state-refine-text string",
+		"-state-refine-file string",
+		"--version | -version",
+	}
+	for _, f := range flags {
+		if !strings.Contains(help, f) {
+			t.Fatalf("help missing flag token %q; help=\n%s", f, help)
+		}
+	}
+
+	// Key phrases to ensure important semantics remain documented
+	phrases := []string{
+		"conflicts with -temp",
+		"conflicts with -prep-top-p",
+		"conflicts with -prep-temp",
+		"mutually exclusive with -prep-system-file",
+		"mutually exclusive with -system",
+		"mutually exclusive with -prompt",
+		"'-' for STDIN",
+		"repeatable",
+		"inherits -http-timeout if unset",
+		"inherits -http-retries if unset",
+		"inherits -http-retry-backoff if unset",
+		"default 1.0",
+		"default 2",
+		"default 500ms",
+		"default 1024x1024",
+		"default standard",
+		"default natural",
+		"default url",
+	}
+	for _, p := range phrases {
+		if !strings.Contains(help, p) {
+			t.Fatalf("help missing key phrase %q; help=\n%s", p, help)
+		}
+	}
+}

--- a/internal/oai/config_helpers.go
+++ b/internal/oai/config_helpers.go
@@ -101,14 +101,14 @@ func ResolveInt(flagSet bool, flagVal int, envStr string, inherit *int, defaultV
 }
 
 // ResolveDuration resolves a time.Duration from flag/env/inherit/default sources and returns the value and source label.
-// - If flagSet is true and flagVal > 0, flagVal is returned with source "flag".
+// - If flagSet is true, flagVal is returned with source "flag" (including 0 to allow explicit disable).
 // - Else if envStr parses via time.ParseDuration() or as an integer seconds value, return that with source "env".
 // - Else if inherit is non-nil, *inherit is returned with source "inherit".
 // - Else defaultVal is returned with source "default".
 func ResolveDuration(flagSet bool, flagVal time.Duration, envStr string, inherit *time.Duration, defaultVal time.Duration) (time.Duration, string) {
-	if flagSet && flagVal > 0 {
-		return flagVal, "flag"
-	}
+    if flagSet {
+        return flagVal, "flag"
+    }
 	if v := strings.TrimSpace(envStr); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
 			return d, "env"


### PR DESCRIPTION
## Summary
- Port a focused subset of `cmd/agentcli` tests from develop (help, flags precedence, docs sync, GPT‑5 mock smoke)
- Align `internal/oai/ResolveDuration` semantics to treat an explicitly set flag value of 0 as intentional, matching develop behavior

## Why
Content-based comparison showed several CLI tests exist on develop but not on main. Running those tests against main revealed a discrepancy in duration resolution where zero values were not honored when set via flags. This ports the tests (verifies behavior) and minimally adjusts the helper to restore intended semantics.

## Notes
- Capabilities output differs on main (JSON summary) vs develop (verbose list); that test was intentionally not ported to avoid duplication/conflict.
- No changes to `main` or `work/develop` branches; work done on topic branch.

## Test plan
- `go test ./...` is green locally
- New tests validate help coverage, flag/env precedence, docs sync, and GPT‑5 request defaults

Ports functionality from develop via content-based comparison; adapted to fit main’s current CLI output shape.